### PR TITLE
Have the handling of the ARMA variable consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Put here the path to Armadillo
-ARMA = /home/johnny/armadillo-10.2.1
+ifndef ARMA
+	ARMA = /home/johnny/armadillo-10.2.1
+endif
 
 # Put here the path to Eigen (optional)
 # You won't need it unless you have to solve a linear system in which

--- a/examples/cpp/Makefile
+++ b/examples/cpp/Makefile
@@ -1,6 +1,9 @@
 MOLE = ../../src/cpp
 
-ARMA = /home/johnny/armadillo-10.2.1
+ifndef ARMA
+	ARMA = /home/johnny/armadillo-10.2.1
+endif
+
 CXX ?= g++ 
 
 ifeq ($(DEBUG),1)

--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -16,7 +16,7 @@
  
 ifndef ARMA
 # Put here the path to Armadillo
-ARMA = /home/johnny/armadillo-10.2.1
+	ARMA = /home/johnny/armadillo-10.2.1
 endif
 
 ifndef EIGEN


### PR DESCRIPTION
Have the handling of the existence of the ARMA variable consistently.  It would probably be better to remove the reference to a developer's location of Armadillo.