### PR TITLE
Introduction to symlink alternatives + warning removal 

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -4,7 +4,7 @@ myst-parser[linkify]>=0.14.0
 sphinx-hoverxref>=0.3b1
 sphinx-design
 sphinx>=5.3,<6
-sphinx_book_theme
+sphinx_rtd_theme
 sphinxcontrib-bibtex==2.5
 sphinxcontrib-katex
 sphinxcontrib-mermaid

--- a/doc/sphinx/source/api/CODE_OF_CONDUCT.rst
+++ b/doc/sphinx/source/api/CODE_OF_CONDUCT.rst
@@ -1,0 +1,6 @@
+==============
+Code of Conduct
+==============
+
+.. include:: ../../../CODE_OF_CONDUCT.md
+   :parser: myst_parser.sphinx_ 

--- a/doc/sphinx/source/api/CONTRIBUTING.rst
+++ b/doc/sphinx/source/api/CONTRIBUTING.rst
@@ -1,0 +1,6 @@
+=======================
+Contributing Guide
+=======================
+
+.. include:: ../../../../CONTRIBUTING.md
+   :parser: myst_parser.sphinx_ 

--- a/doc/sphinx/source/api/cpp_api.rst
+++ b/doc/sphinx/source/api/cpp_api.rst
@@ -1,23 +1,21 @@
+===================
 C++ API Documentation
-=====================
+===================
 
 The **MOLE C++ API** provides low-level access to the mimetic operators and boundary condition functions. This section describes the core classes, functions, and examples for utilizing the API in your C++ applications.
 
--------------
+---------------
 Table of Contents
--------------
+---------------
 
 - **Divergence Class**: Handles the computation of divergence operators.
-
 - **Gradient Class**: Computes the gradient of scalar fields.
-
 - **Laplacian Class**: Supports Laplacian operations on grid-based structures.
-
 - **Boundary Conditions**: Manage Dirichlet, Neumann, and Robin boundary conditions.
 
--------------
-**C++ API Reference**
----------------------
+---------------
+C++ API Reference
+---------------
 .. doxygenindex:: 
    :project: MoleCpp
 

--- a/doc/sphinx/source/api/gettingstarted.rst
+++ b/doc/sphinx/source/api/gettingstarted.rst
@@ -1,0 +1,33 @@
+==============
+Getting Started
+==============
+
+This guide will help you get started with MOLE.
+
+-----------
+Installation
+-----------
+
+^^^^^^^^^^^^
+Prerequisites
+^^^^^^^^^^^^
+- C++17 compatible compiler
+- CMake 3.10 or higher
+- MATLAB (optional, for MATLAB API)
+
+^^^^^^^^^^^^^^^^^^
+Building from Source
+^^^^^^^^^^^^^^^^^^
+
+1. Clone the repository:
+
+.. code-block:: bash
+
+   git clone https://github.com/csrc-sdsu/mole.git
+   cd mole
+
+2. Build the library:
+
+.. code-block:: bash
+
+   make 

--- a/doc/sphinx/source/api/matlab_api.rst
+++ b/doc/sphinx/source/api/matlab_api.rst
@@ -1,21 +1,21 @@
+================================
 MATLAB API Documentation
-========================
+================================
 
 The **MATLAB API** for MOLE provides access to mimetic operators, solvers, and pre-processing routines within MATLAB. This API allows MATLAB users to leverage the computational power of C++-based mimetic operators while working in a familiar MATLAB environment.
 
+-----------------------
 Key Functions
--------------
+-----------------------
 
 - **Divergence**: Computes the divergence of a vector field.
-
 - **Gradient**: Computes the gradient of a scalar field.
-
 - **Laplacian**: Computes the Laplacian of a field.
-
 - **Boundary Conditions**: Set boundary conditions directly in MATLAB scripts.
 
+------------------------------------
 Reference Documentation
--------------
+------------------------------------
 
 The MATLAB API documentation can be found at the link below:
 `MATLAB API Reference <../../../api_docs/matlab/index.html>`_

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -20,22 +20,33 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.githubpages',
-    'sphinx_book_theme',
+    'sphinx_rtd_theme',
+    'myst_parser',
 ]
+
+# Configure myst-parser
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+]
+
+# Add support for Markdown files
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 templates_path = ['_templates']
 exclude_patterns = []
 
 # -- Options for HTML output -------------------------------------------------
 
-html_theme = 'sphinx_book_theme'
+html_theme = 'sphinx_rtd_theme'
 
 html_theme_options = {
-    "repository_url": "https://github.com/csrc-sdsu/mole",
-    "use_repository_button": True,
-    "use_issues_button": True,
-    "use_edit_page_button": True,
-    "path_to_docs": "doc/sphinx/source",
+    "style_external_links": True,
+    "logo_only": True,
+    "navigation_depth": 4,
 }
 
 html_static_path = []

--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -3,27 +3,51 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+=================
 MOLE Documentation
-==================
+=================
 
-Welcome to MOLE (Mimetic Operators Library Enhanced) documentation. MOLE is a comprehensive library for numerical computations focusing on mimetic finite difference methods.
+--------------------------------------------------
+Welcome to MOLE (Mimetic Operators Library Enhanced)
+--------------------------------------------------
 
-**Key Features:**
+MOLE is a comprehensive library for numerical computations focusing on mimetic finite difference methods.
 
-- Mimetic finite difference operators
-- Support for various boundary conditions
-- High-performance numerical computations
-- Cross-platform compatibility
-- Extensive example collection
+.. image:: ../../../logo.png
+   :align: center
+   :width: 200px
+
+--------------------------------------------------
+Key Features
+--------------------------------------------------
+
+* Mimetic finite difference operators
+* Support for various boundary conditions
+* High-performance numerical computations
+* Cross-platform compatibility (C++ and MATLAB implementations)
+* Extensive example collection
+
+--------------------------------------------------
+Contents
+--------------------------------------------------
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
+   :maxdepth: 4
+   :caption: Documentation
    
    api/introduction
    api/cpp_api
    api/matlab_api
+   api/gettingstarted
+   Contributing Guide <api/CONTRIBUTING>
+   Code of Conduct <api/CODE_OF_CONDUCT>
+   
+--------------------------------------------------
+Indices and Tables
+--------------------------------------------------
+
+* :ref:`genindex`
+* :ref:`search`
 
 .. **Doxygen API Documentation**
 
@@ -40,8 +64,9 @@ Welcome to MOLE (Mimetic Operators Library Enhanced) documentation. MOLE is a co
 
 ..    ../../doc/api_docs/matlab/mole_MATLAB/index.html
 
+--------------------------------------------------
 **More Information**
---------------------
+--------------------------------------------------
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
The file linking from the root directory is introduced in this PR.
The absence of a title prevented the symlinks from linking [seems to be a requirement for Sphinx compilation].

- For now, Sphinx's built-in `include` function is being used to handle them.
- Introduction to 'sphinx_rtd_theme' for better support
- Each short title string warning is resolved.

Closes #48