### PR TITLE
Latex pdf builder package replacement 

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -11,4 +11,3 @@ sphinxcontrib-mermaid
 sphinxcontrib-svg2pdfconverter
 sphinxext-altair
 docutils<0.21
-xindy

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -126,6 +126,8 @@ latex_elements = {
     'hyperref': r'''
         \usepackage[hidelinks]{hyperref}
     ''',
+    'makeindex': '\\makeindex',  # Use makeindex instead of xindy
+    'printindex': '\\printindex',
 }
 
 latex_documents = [


### PR DESCRIPTION
`xindy` is not a Python package but rather a LaTeX/texlive package that should be installed through the system package manager instead of pip. so, I am switching it with `makeindex` to relieve some dependencies 

This approach: 
1. Makes PDF generation work even without xindy (just with reduced functionality - no index generation)
2. Keeps HTML documentation working regardless of LaTeX installation status
3. **Doesn't require users to manually install xindy**

The PDF will still generate, just without the index if xindy isn't available. This is often an acceptable compromise for many projects.

[Closes #84 ]

