### PR TITLE
.gitignore changes corresponding to new cMake system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,54 +1,62 @@
-# General ignore patterns
+# Build and binary directories
+/build/
+/bin/
+/lib/
+/dist/
+/src/mole_C++/*.o
+/src/mole_C++/*.a
+/src/cpp/*.o
+/src/cpp/*.a
 
-!*.*
-!*/
+# CMake generated files
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+*.cmake
+!CMakeLists.txt
 
-# Ignore build artifacts and temporary files
-*.o
-*.so
-*.a
-*.asv
-*~
+# Documentation generated files
+/doc/api_docs/cpp
+# /doc/api_docs/matlab # TODO: add this back in once we work to update or integrate the MATLAB API.
+/doc/sphinx/build/
+/doc/sphinx/_build/
+# /doc/sphinx/source/api/ # TODO: add this back in once the API is updated and the final docs are built.
 
-# Ignore Doxygen generated HTML and XML output
-doc/api_docs/cpp  
-# Ignore Sphinx build output
-doc/sphinx/build/
-
-# Mac specific
-.DS_Store
-*.dSYM
-*~
-*.dylib
-
-# Python
-dist
-*egg*
-.pytest_cache
-*cffi.so
-*cffi.dylib
+# Python related
 __pycache__/
-.ipynb_checkpoints/
+*.py[cod]
+.env
+.venv
+env/
+venv/
+*.egg-info/
 
-# Editor Misc
+# MATLAB related
+*.asv
+
+# IDE and editor files
+.vscode/
+.idea/
+.vim/
 .cache/
-.history
-.vscode
-.ccls-cache
-.vim
+.ccls-cache/
+*.swp
+*~
 
-# Don't try to track executables
-examples/cpp/RK2
-examples/cpp/convection_diffusion3D
-examples/cpp/elliptic1D
-examples/cpp/elliptic2D
-examples/cpp/parabolic1D
-examples/cpp/plot.gnu
-examples/cpp/schrodinger1D
-examples/cpp/transport1D
-tests/cpp/test1
-tests/cpp/test2
-tests/cpp/test3
-tests/cpp/test4
-tests/cpp/test5
+
+# OS specific files
+.DS_Store
+.DS_Store?
+._*
+Thumbs.db
+
+# Project specific executables
+/examples/cpp/RK2
+/examples/cpp/convection_diffusion3D
+/examples/cpp/elliptic[12]D
+/examples/cpp/parabolic1D
+/examples/cpp/schrodinger1D
+/examples/cpp/transport1D
+/examples/cpp/plot.gnu
+/tests/cpp/test[1-5]
 


### PR DESCRIPTION
* 1\. Added Leading Slashes which make paths explicit to root directory, prevents accidental matches in subdirectories. 
* 2\. Removed `!*.*` and `!*/:` These patterns were too broad and could cause confusion.  
* 3\. Created a dedicated "Build and binary directories" section 
    * 3.1\. Added Missing Build Directories: Added `/bin/`, `/lib/,` `/dist/`
    * 3.2\. Made Binary Paths More Specific: Changed from generic `*.o `to `/src/mole_C++/*.o`
* 4\. Consolidated Documentation Patterns
* 5\. Python-Related
    * 5.1\. Removed redundant entries like `*cffi.so`, `*cffi.dylib`
    * 5.2\. Consolidated into `*.py[cod]` and` __pycache__/`
    * 5.3\. Removed `.ipynb_checkpoints/` as it wasn't relevant to the project
* 6\. Removed `.history` as it's covered by `.vscode/`
* 7\. Added common editor backup patterns `(*.swp, *~)`
* 8\. Removed `*.dSYM` as it's specific to debug symbols and should be in build directory
* 9\. Removed` *.dylib` as it's covered by build directory exclusions
* 10\. Removed redundant `*~` entries
* 11\. Optimized Executable Patterns
    * 11.1\. Changed `elliptic1D` and `elliptic2D` to `elliptic[12]D`
    * 11.2\. likewise for `/tests/cpp/test[1-5]`
* 12\. Misc.

[Closes #83]






