### PR TITLE
IntelLLVM support extended

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,23 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/opt/libomp/lib -L/opt/homebrew/opt/libomp/lib -lomp")
     message(STATUS "Using AppleClang-specific flags.")
     include_directories("/usr/local/opt/libomp/include" "/opt/homebrew/opt/libomp/include")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    	set(CMAKE_CXX_FLAGS "-O3 -qopenmp -DARMA_DONT_USE_WRAPPER -DARMA_USE_SUPERLU -diag-disable=10430")
+    	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+    	message(STATUS "Using non-Clang compiler flags.")
+    	# Get MKLROOT from environment or fallback to default
+    	if(DEFINED ENV{MKLROOT})
+        	set(MKLROOT $ENV{MKLROOT})
+    	else()
+        	set(MKLROOT "/opt/intel/oneapi/mkl/latest")
+    	endif()
+
+    	# Automatically set Armadillo to link against MKL
+    	set(BLAS_LIBRARIES "${MKLROOT}/lib/intel64/libmkl_rt.so" CACHE STRING "BLAS library path for MKL")
+    	set(LAPACK_LIBRARIES "${MKLROOT}/lib/intel64/libmkl_rt.so" CACHE STRING "LAPACK library path for MKL")
+    	set(ARMA_USE_WRAPPER OFF CACHE BOOL "Disable Armadillo wrapper to directly use MKL")
+
+    	message(STATUS "Using MKL from: ${MKLROOT}")
 else()
     set(CMAKE_CXX_FLAGS "-O3 -fopenmp -DARMA_DONT_USE_WRAPPER -DARMA_USE_SUPERLU")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
<!--
     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/master/CONTRIBUTING.md
     - 📖 Read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/master/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
     - 📝 Add license information in the appropriate place. See MATLAB or C++ code for reference.
      
          SPDX-License-Identifier: GPL-3.0-or-later
          © 2008-2024 San Diego State University Research Foundation (SDSURF).
          See LICENSE file or https://www.gnu.org/licenses/gpl-3.0.html for details. 

     NOTE: Pull Requests from forked repositories need to be reviewed by
     a MOLE Team member before any CI builds will run.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
### Issue:
A user encountered a linker warning during the build:

`/usr/bin/ld: warning: libmkl_rt.so.2, needed by libarmadillo.so, not found`

This occurred because Armadillo had been linked against Intel MKL, but the MKL runtime (libmkl_rt.so) was not discoverable by the system at runtime. The issue was only resolved when the user manually sourced the Intel oneAPI environment, allowing the linker to find the required MKL libraries.

### Resolution:
The CMakeLists.txt was updated to:

- Automatically detect if the Intel oneAPI icpx compiler (CMAKE_CXX_COMPILER_ID == IntelLLVM) is being used.

- If detected:

    - Retrieve MKLROOT from the environment or fallback to a default path.

    - Set BLAS and LAPACK paths to point to MKL.

    - Configure Armadillo to link against MKL without requiring user input.
## Related Issues & Documents

<!--
For Pull Requests that relate or close an Issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Closes #129 

 ## QA Instructions, Screenshots, Recordings

To test the updated CMake configuration with Intel oneAPI compilers, ensure you have the Intel oneAPI toolkit installed and the environment sourced

`. /opt/intel/oneapi/setvars.sh`

Then,

```
mkdir build && cd build
cmake .. -DCMAKE_CXX_COMPILER=icpx
make -j
```
The output file will have the following lines
```

oneapi@oneapi-Precision-5820-Tower:~/mole/build$ cmake .. -DCMAKE_CXX_COMPILER=icpx
-- The CXX compiler identification is IntelLLVM 2025.1.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/intel/oneapi/compiler/2025.1/bin/icpx - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detected CXX Compiler ID: IntelLLVM
-- Using non-Clang compiler flags.
-- Using MKL from: /opt/intel/oneapi/mkl/2025.1
-- SuperLU CMakeLists.txt after patch: cmake_minimum_required(VERSION 3.10)
```
<!-- _Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._-->

## Added/updated tests?
- We encourage you to test all code included with MOLE, including examples.

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] I have read and followed the [Contributing Guide](https://github.com/csrc-sdsu/mole/blob/master/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/csrc-sdsu/mole/blob/master/CODE_OF_CONDUCT.md)
<!--
## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://miro.medium.com/v2/1*VpQb2kbPdj6vXH2pJqi7Qg.gif" width="100" height="100" /> -->
