### PR TITLE
force link of installed gfortran

### DIFF
--- a/.github/workflows/build_and_gtest.yml
+++ b/.github/workflows/build_and_gtest.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install cmake openblas eigen libomp lapack
-          sudo ln -s /opt/homebrew/bin/gfortran-14 /opt/homebrew/bin/gfortran
+          sudo ln -sf /opt/homebrew/bin/gfortran-14 /opt/homebrew/bin/gfortran
         
       - name: Export Environment Variables
         run: |


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
Fixes error that may be generated if gfortran exists. This forces liking with the new version.

## Related Issues & Documents
#139 

- Closes #
closes #139 