### PR TITLE
Update authors of User Manual in doc configuration file

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -33,7 +33,9 @@ sys.path.insert(0, os.path.abspath('_ext'))
 #------------------------------------------------------------------------------
 project = 'MOLE'
 copyright = '2023, CSRC SDSU'
-author = 'CSRC SDSU'
+with open("../../../AUTHORS") as f:
+    authorlist = f.readlines()
+author = ", ".join(authorlist)
 release = '1.1.0'
 master_doc = 'index'
 root_doc = 'index'
@@ -411,14 +413,16 @@ latex_elements = {
 }
 
 # Main LaTeX/PDF document configuration
+
+latexauthorslist = r" \and ".join(authorlist)
 latex_documents = [
     (
-        'index',           # Source start file
-        'MOLE-docs.tex',   # Target filename
-        'MOLE User Manual',        # Title
-        'CSRC SDSU',       # Author
-        'manual',          # Document class
-        False              # toctree_only
+        'index',            # Source start file
+        'MOLE-docs.tex',    # Target filename
+        'MOLE User Manual', # Title
+        latexauthorslist,   # Author
+        'manual',           # Document class
+        False               # toctree_only
     ),
 ]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [x] Documentation

## Description
Now that we have added an `AUTHORS` file, this PR populates the User Manual PDF authors entry properly.

## Related Issues & Documents

- Closes #186 


