### PR TITLE
Add Zenodo citing info 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,22 +1,54 @@
 cff-version: "1.2.0"
+title: "MOLE: Mimetic Operators Library Enhanced"
+message: "Please cite the following works when using this software."
 authors:
-- family-names: Corbino
-  given-names: Johnny
-  orcid: "https://orcid.org/0000-0002-2638-9216"
-- family-names: Dumett
-  given-names: Miguel A.
+- family-names: Barra
+  given-names: Valeria
+  orcid: 0000-0003-1129-2056
+- family-names: Boada
+  given-names: Angel
+- family-names: Brzenski
+  given-names: Jared
 - family-names: Castillo
-  given-names: Jose E.
-contact:
+  given-names: Jose
+- family-names: Chakalasiya
+  given-names: Prit
+- family-names: Singh
+  given-names: Surinder Chhabra
 - family-names: Corbino
   given-names: Johnny
-  orcid: "https://orcid.org/0000-0002-2638-9216"
-doi: 10.5281/zenodo.12752946
+  orcid: 0000-0002-2638-9216
+- family-names: Drummond
+  given-names: Tony
+- family-names: Dumett
+  given-names: Miguel
+- family-names: Hellmers
+  given-names: Joe
+- family-names: Ilaty
+  given-names: Arshia
+- family-names: Kaviani
+  given-names: Katayoon
+- family-names: Nzerem
+  given-names: Oluchi
+- family-names: Pagallo
+  given-names: Giulia
+- family-names: Paolini
+  given-names: Christopher
+- family-names: Rosano
+  given-names: Valentina
+- family-names: Srinivas
+  given-names: Aneesh Murthy
+- family-names: Srinivasan
+  given-names: Janani Priyadharshini
+- family-names: Valera
+  given-names: Manuel
+doi: https://zenodo.org/records/16898575
 version: "1.1.0"
 date-released: "2025-08-13"
-message: If you use this software, please cite our article in the
-  Journal of Open Source Software.
+url: https://mole-docs.readthedocs.io/en/main/
+repository: https://github.com/csrc-sdsu/mole
 preferred-citation:
+  message: If you use this software, please also cite our article in the Journal of Open Source Software.
   authors:
   - family-names: Corbino
     given-names: Johnny
@@ -37,4 +69,3 @@ preferred-citation:
   type: article
   url: "https://joss.theoj.org/papers/10.21105/joss.06288"
   volume: 9
-title: "MOLE: Mimetic Operators Library Enhanced"

--- a/README.md
+++ b/README.md
@@ -169,10 +169,57 @@ We welcome contributions to MOLE, including:
 
 Please refer to our [Contribution Guidelines](https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md) for more details.
 
-## Citations
+## How to Cite
 
 Please cite our work if you use MOLE in your research or software.
 Citations are helpful for the continued development and maintenance of the library.
+
+```bibtex
+@article{Corbino2024, 
+   doi = {10.21105/joss.06288}, 
+   url = {https://doi.org/10.21105/joss.06288}, 
+   year = {2024}, 
+   publisher = {The Open Journal}, 
+   volume = {9}, 
+   number = {99}, 
+   pages = {6288}, 
+   author = {Corbino, Johnny and Dumett, Miguel A. and Castillo, Jose E.}, 
+   title = {MOLE: Mimetic Operators Library Enhanced}, 
+   journal = {Journal of Open Source Software} }
+```
+
+The archival copy of the MOLE User Manual is maintained on [Zenodo](https://zenodo.org/records/16898575). To cite the User Manual please use:
+
+```bibtex
+@misc{MOLE_user_manual,
+   author       = {Barra, Valeria and
+                  Boada, Angel and
+                  Brzenski, Jared and
+                  Castillo, Jose and
+                  Chakalasiya, Prit and
+                  Singh, Surinder Chhabra and
+                  Corbino, Johnny Delgado and
+                  Drummond, Tony and
+                  Dumett, Miguel and
+                  Hellmers, Joe and
+                  Ilaty, Arshia and
+                  Kaviani, Katayoon and
+                  Nzerem, Oluchi and
+                  Pagallo, Giulia and
+                  Paolini, Christopher and
+                  Rosano, Valentina and
+                  Srinivas, Aneesh Murthy and
+                  Srinivasan, Janani Priyadharshini and
+                  Valera, Manuel},
+   title        = {{MOLE User Manual}},
+   month        = aug,
+   year         = 2025,
+   publisher    = {Zenodo},
+   version      = {1.1.0},
+   doi          = {10.5281/zenodo.16898575},
+   url          = {https://doi.org/10.5281/zenodo.16898575},
+}
+```
 
 ## Gallery
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,7 +80,7 @@ For DOI-bearing releases:
 
 1. **Generate documentation PDF**: The documentation workflow automatically generates a PDF version
 2. **Update Zenodo record**: 
-   - Visit the [MOLE Zenodo record](https://zenodo.org/record/12752946) (update URL as needed)
+   - Visit the [MOLE Zenodo record](https://zenodo.org/records/16898575) (update URL as needed)
    - Click "New version"
    - Upload the generated PDF documentation
    - Update author information if applicable


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [x] Documentation

## Description

## Related Issues & Documents
This PR adds the new Zenodo User Manual citing info and updates the `README.md`, `RELEASING.md` and `CITATION.cff` files with the current information.

- Closes #188 
