### PR TITLE
fixed octave incompatibility with test_curl.m

### DIFF
--- a/examples/matlab_octave/test_curl.m
+++ b/examples/matlab_octave/test_curl.m
@@ -3,9 +3,9 @@
 % field to obtain the equivalent curl. The proper way to solve problems
 % that involve the curl operator is by calling the function curl2D(...)
 %
-% This calculates the curl usingt he divergence like equation 45 in
+% This calculates the curl using the divergence like equation 45 in
 % Corbino, Castillo, "High-order mimetic finite-difference operators
-% the extended Gauss divergence theorem". 2019
+% satisfying the extended Gauss divergence theorem". 2019
 % https://doi.org/10.1016/j.cam.2019.06.042
 
 clc

--- a/examples/matlab_octave/test_curl.m
+++ b/examples/matlab_octave/test_curl.m
@@ -1,12 +1,22 @@
 % This file does not uses the curl2D(...) function provided by the library.
-% It just tests the 2D mimetic divergence applied to an auxiliary vector 
-% field to obtain the equivalent curl. The proper way to solve problems 
+% It just tests the 2D mimetic divergence applied to an auxiliary vector
+% field to obtain the equivalent curl. The proper way to solve problems
 % that involve the curl operator is by calling the function curl2D(...)
+%
+% This calculates the curl usingt he divergence like equation 45 in
+% Corbino, Castillo, "High-order mimetic finite-difference operators
+% the extended Gauss divergence theorem". 2019
+% https://doi.org/10.1016/j.cam.2019.06.042
 
 clc
 close all
+clear all
 
 addpath('../../src/matlab_octave')
+
+% This P and Q will produce a scalar curl = 2
+P = @(~, Y) -Y;   % U(x,y) = -y
+Q = @(X, ~)  X;   % V(x,y) =  x
 
 order =   2;
 west  = -10;
@@ -35,7 +45,7 @@ end
 for j = 1 : 2 : 2*n+1
     for i = 2 : 2 : 2*m+1
         F(k) = -P(xaxis(i), yaxis(j)); % Important!
-        k = k + 1;   
+        k = k + 1;
     end
 end
 
@@ -56,12 +66,3 @@ zlabel('z')
 set(gcf, 'color', 'w')
 view(0, 90)
 axis tight
-
-% This P and Q will produce a scalar curl = 2
-function U = P(~, Y)
-  U = -Y;
-end
-
-function V = Q(X, ~)
-  V = X;
-end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
Fixes Octave error for test_curl.m. Octave cannot do in-code functions, like MATLAB. Actually, it does it the reverse, Python style, where they need to be declared first.

## Related Issues & Documents
- Closes #162 

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [X] No, and this is why: it is a test
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [X] I have read and followed the [Contributing Guide](https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md)

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://miro.medium.com/v2/1*VpQb2kbPdj6vXH2pJqi7Qg.gif" width="100" height="100" />
