### PR TITLE
Test new stub Fortran gradient operator with Julienne

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,10 +1,10 @@
 name = "MOLE"
 
 [dependencies]
-armadillo-code = {git = "https://gitlab.com:rouson/armadillo-code.git", tag = "fpm"}
+armadillo-code = {git = "https://gitlab.com/rouson/armadillo-code.git", tag = "fpm"}
 
 [dev-dependencies]
-julienne = {git = "https://github.com:berkeleylab/julienne.git", tag = "3.1.3"}
+julienne = {git = "https://github.com/berkeleylab/julienne.git", tag = "3.1.3"}
 
 [install]
 library = true

--- a/fpm.toml
+++ b/fpm.toml
@@ -3,5 +3,8 @@ name = "MOLE"
 [dependencies]
 armadillo-code = {git = "git@gitlab.com:rouson/armadillo-code.git", tag = "fpm"}
 
+[dev-dependencies]
+julienne = {git = "git@github.com:berkeleylab/julienne.git", tag = "3.1.2"}
+
 [install]
 library = true

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,10 +1,10 @@
 name = "MOLE"
 
 [dependencies]
-armadillo-code = {git = "git@gitlab.com:rouson/armadillo-code.git", tag = "fpm"}
+armadillo-code = {git = "https://gitlab.com:rouson/armadillo-code.git", tag = "fpm"}
 
 [dev-dependencies]
-julienne = {git = "git@github.com:berkeleylab/julienne.git", tag = "3.1.2"}
+julienne = {git = "https://github.com:berkeleylab/julienne.git", tag = "3.1.3"}
 
 [install]
 library = true

--- a/fpm.toml
+++ b/fpm.toml
@@ -2,3 +2,6 @@ name = "MOLE"
 
 [dependencies]
 armadillo-code = {git = "git@gitlab.com:rouson/armadillo-code.git", tag = "fpm"}
+
+[install]
+library = true

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,4 @@
+name = "MOLE"
+
+[dependencies]
+armadillo-code = {git = "git@gitlab.com:rouson/armadillo-code.git", tag = "fpm"}

--- a/src/fortran/grad_op_m.f90
+++ b/src/fortran/grad_op_m.f90
@@ -1,0 +1,29 @@
+module grad_op_m
+  !! Define a mimetic gradient operator abstraction
+  implicit none
+
+  private
+  public :: grad_op_t
+
+  type grad_op_t
+    !! Encapsulate mimetic gradient operator values and defined operations
+    private
+    double precision, allocatable :: coeffs_(:,:)
+    integer k_, m_
+    double precision dx_
+  end type
+
+  interface grad_op_t
+    
+    pure module function grad_op_1D(k, m, dx) result(grad_op)
+      !! Define a 
+      implicit none
+      integer, intent(in) :: k !! order of accuracy
+      integer, intent(in) :: m !! number of cells
+      double precision, intent(in) :: dx !! step size
+      type(grad_op_t) grad_op
+    end function
+
+  end interface
+  
+end module grad_op_m

--- a/src/fortran/grad_op_s.f90
+++ b/src/fortran/grad_op_s.f90
@@ -1,0 +1,12 @@
+submodule(grad_op_m) grad_op_s
+  implicit none
+
+contains
+
+  module procedure grad_op_1D
+    grad_op%k_ = k
+    grad_op%m_ = m
+    grad_op%dx_ = dx
+  end procedure
+
+end submodule grad_op_s

--- a/test/driver.f90
+++ b/test/driver.f90
@@ -1,0 +1,13 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in https://github.com/BerkeleyLab/julienne/blob/3.1.2/LICENSE.txt
+program test_suite_driver
+  use julienne_m, only : test_fixture_t, test_harness_t
+  use grad_op_test_m, only : grad_op_test_t
+  implicit none
+
+  associate(test_harness => test_harness_t([ &
+     test_fixture_t(grad_op_test_t()) &
+  ]))
+    call test_harness%report_results
+  end associate
+end program test_suite_driver

--- a/test/grad_op_test_m.F90
+++ b/test/grad_op_test_m.F90
@@ -1,10 +1,16 @@
 ! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
 ! Terms of use are as specified in https://github.com/BerkeleyLab/julienne/blob/3.1.2/LICENSE.txt
 
+#include "language-support.F90"
+  !! include Julienne preprocessor  macros
+
 module grad_op_test_m
   use julienne_m, only : &
      test_t, test_description_t, test_diagnosis_t, test_result_t
   use grad_op_m, only : grad_op_t
+#if ! HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
+  use julienne_m, only : diagnosis_function_i
+#endif
   implicit none
 
   type, extends(test_t) :: grad_op_test_t
@@ -20,6 +26,8 @@ contains
     test_subject = 'A grad_op operator'
   end function
 
+#if HAVE_PROCEDURE_ACTUAL_FOR_POINTER_DUMMY
+
   function results() result(test_results)
     type(grad_op_test_t) grad_op_test
     type(test_result_t), allocatable :: test_results(:)
@@ -27,6 +35,21 @@ contains
       [test_description_t('can be constructed', check_construction) &
     ])
   end function
+
+#else
+
+  function results() result(test_results)
+    type(grad_op_test_t) grad_op_test
+    type(test_result_t), allocatable :: test_results(:)
+    procedure(diagnosis_function_i), pointer :: &
+      check_construction_ptr => check_construction
+
+    test_results = grad_op_test%run( &
+      [test_description_t('can be constructed', check_construction_ptr) &
+    ])
+  end function
+
+#endif
 
   function check_construction() result(test_diagnosis)
     type(test_diagnosis_t) test_diagnosis

--- a/test/grad_op_test_m.f90
+++ b/test/grad_op_test_m.f90
@@ -1,0 +1,38 @@
+! Copyright (c) 2024-2025, The Regents of the University of California and Sourcery Institute
+! Terms of use are as specified in https://github.com/BerkeleyLab/julienne/blob/3.1.2/LICENSE.txt
+
+module grad_op_test_m
+  use julienne_m, only : &
+     test_t, test_description_t, test_diagnosis_t, test_result_t
+  use grad_op_m, only : grad_op_t
+  implicit none
+
+  type, extends(test_t) :: grad_op_test_t
+  contains
+    procedure, nopass :: subject
+    procedure, nopass :: results
+  end type
+
+contains
+
+  pure function subject() result(test_subject)
+    character(len=:), allocatable :: test_subject
+    test_subject = 'A grad_op operator'
+  end function
+
+  function results() result(test_results)
+    type(grad_op_test_t) grad_op_test
+    type(test_result_t), allocatable :: test_results(:)
+    test_results = grad_op_test%run( & 
+      [test_description_t('can be constructed', check_construction) &
+    ])
+  end function
+
+  function check_construction() result(test_diagnosis)
+    type(test_diagnosis_t) test_diagnosis
+    associate(grad_op => grad_op_t(k=2, m=2, dx=1D0))
+    end associate
+    test_diagnosis = test_diagnosis_t(test_passed=.true., diagnostics_string="failure is not an option")
+  end function
+
+end module

--- a/test/test-suite.json
+++ b/test/test-suite.json
@@ -1,0 +1,5 @@
+{
+    "test suite": {
+        "test subjects" : ["grad_op"]
+    }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
    
This PR adds

* A a stub gradient operator comprising 
  - A `grad_op_m` module containing a `grad_op_t` derived type and constructor interface and
  - A `grad_op_s` submodule constructor function definition.
* A  Julienne unit test in the `grad_op_test_m` module that simply checks that the constructor executes 
* A `driver` test-suite main program that executes the test.

Julienne's `scaffold` utility generated the initial versions of the test module and driver program so those two files have leading comments referring to the Julienne license.   The  stub constructor can be invoked as `grad_op_t(k,m,dx)`, where `k`, `m`, and `dx` are the order of accuracy, the number of cells, and the step size, respectively.  The arguments are stored but nothing else is computed yet.

## QA Instructions, Screenshots, Recordings

With the Fortran Package Manager (`fpm`) installed and `gfortran` 14 or later, test this PR by running
```
fpm test --profile release
```
When using `gfortran` 13, please append `--flag "-ffree-line-length-none"` to the above command.

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] I have read and followed the [Contributing Guide](https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md)

## What gif best describes this PR or how it makes you feel?

:rocket:
