### PR TITLE
Add automatic GitHub stat tracking

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,0 +1,20 @@
+name: github-repo-stats
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: github-repo-stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        # Use latest release.
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.ghrs_github_api_token }}
+

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -16,5 +16,6 @@ jobs:
         # Use latest release.
         uses: jgehrcke/github-repo-stats@RELEASE
         with:
+          # The secret 'ghrs_github_api_token' must be configured in the repository settings.
+          # It should have appropriate permissions for reading repository statistics.
           ghtoken: ${{ secrets.ghrs_github_api_token }}
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
This uses the automatic GitHub stats tracking from the [jgehrcke](https://github.com/jgehrcke/github-repo-stats) repository to track all of the stats GitHub only holds for two weeks.

The results are held in an existing empty branch called github-repo-stats. There is an assortment of logs and reports generated that will exist only in that branch. They will be useful later for measuring the growth of the library. See examples of results from my rockfish-helpers repo [HERE](https://github.com/jbrzensk/rockfish_helpers/tree/github-repo-stats/jbrzensk/rockfish_helpers).

## QA Instructions, Screenshots, Recordings
From the actions tab run "github-repo-stats"

## Read Contributing Guide and Code of Conduct

- [X] I have read and followed the [Contributing Guide](https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md)

<img src="https://miro.medium.com/v2/1*VpQb2kbPdj6vXH2pJqi7Qg.gif" width="100" height="100" />
