### PR TITLE
error check for system gnuplot call

### DIFF
--- a/examples/cpp/hyperbolic1D_upwind.cpp
+++ b/examples/cpp/hyperbolic1D_upwind.cpp
@@ -124,6 +124,13 @@ int main()
     scriptFile.close();
 
     // Run GNUplot with the script
-    system("gnuplot -persistent gp_script");
+    int status = std::system("gnuplot -persistent gp_script");
+
+    if ( status != 0 ) {
+        std::cerr << "Error executing GNUplot.\n";
+        return EXIT_FAILURE;
+    }
+ 
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Example
- [ ] Documentation

## Description
Fixes the compile warning about system command with unused return value. Now checks return value and outputs error if it occurs.

## Related Issues & Documents

- Closes #250 

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [X] No, and this is why: existing tests sufficient
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [X] I have read and followed the [Contributing Guide](https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md)
