### PR TITLE
julia/MOLE.jl: Add addScalarBC, relative BCs tests and elliptic1DaddScalarBC example 

### DIFF
--- a/julia/MOLE.jl/Project.toml
+++ b/julia/MOLE.jl/Project.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/julia/MOLE.jl/examples/elliptic1DaddScalarBC.jl
+++ b/julia/MOLE.jl/examples/elliptic1DaddScalarBC.jl
@@ -1,0 +1,49 @@
+using LinearAlgebra
+using SparseArrays
+using Plots
+
+import MOLE: Operators, BCs
+
+# Domain limits
+west = 0.0
+east = 1.0
+
+k  = 6 # operator order of accuracy
+m  = 2k + 1 # minimum number of cells to attain desired accuracy
+dx = (east - west) / m # step length
+
+# 1D staggered grid
+grid = [west; (west + dx/2):dx:(east - dx/2); east]
+
+# Mimetic Laplacian operator
+L = Operators.lap(k, m, dx)
+
+# Robin boundary conditions:  dc*u + nc*(du/dn) = v
+dc = (1.0, 1.0)
+nc = (1.0, 1.0)
+v  = (0.0, 2 * exp(1.0))
+
+bc = BCs.ScalarBC1D(dc, nc, v)
+
+# RHS
+rhs = exp.(grid)
+
+# Apply boundary conditions and construct new system matrix/array
+L0, rhs0 = BCs.addScalarBC!(sparse(L), rhs, bc, k, m, dx)
+
+# Solve linear system
+u = L0 \ rhs0
+
+# Plot
+p = scatter(grid, u; label="Approximated", marker=:circle)
+plot!(p, grid, exp.(grid); label="Analytical")
+plot!(
+    p, 
+    title="Poisson's equation with Robin BC",
+    xlabel="x",
+    ylabel="u(x)",
+    legend=:topleft
+)
+display(p)
+println("Press Enter to close the plot and exit.")
+readline()

--- a/julia/MOLE.jl/src/BCs/BCs.jl
+++ b/julia/MOLE.jl/src/BCs/BCs.jl
@@ -1,5 +1,8 @@
 module BCs
 
+using SparseArrays
+
 include("robinBC.jl")
+include("scalarBC.jl")
 
 end # module BCs

--- a/julia/MOLE.jl/src/BCs/scalarBC.jl
+++ b/julia/MOLE.jl/src/BCs/scalarBC.jl
@@ -1,0 +1,115 @@
+#=
+    SPDX-License-Identifier: GPL-3.0-or-later
+    © 2008-2024 San Diego State University Research Foundation (SDSURF).
+    See LICENSE file or https://www.gnu.org/licenses/gpl-3.0.html for details.
+=#
+
+import ..Operators: Operators, grad
+
+"""
+    Abstract supertype for scalar boundary-condition applicators.
+
+    `D` is the spatial dimension (1,2,3,...).
+"""
+abstract type AbstractScalarBC{D} end
+
+
+"""
+    Concrete scalar BC description for 1D.
+
+    Fields mirror the MATLAB function:
+    - dc: Dirichlet coefficients (left,right)
+    - nc: Neumann/Robin coefficients (left,right)
+    - v:  prescribed boundary value g (left,right)
+"""
+struct ScalarBC1D{T} <: AbstractScalarBC{1}
+    dc::NTuple{2,T}
+    nc::NTuple{2,T}
+    v::NTuple{2,T}
+end
+
+# -------------------------
+# 1D implementation
+# -------------------------
+
+"""
+    Internal helper: build LHS contributions for 1D BC.
+    Returns (Al, Ar).
+"""
+function _scalarbc1d_lhs(k::Integer, m::Integer, dx, dc::NTuple{2,T}, nc::NTuple{2,T}) where {T}
+    n = m + 2
+
+    Al = spzeros(T, n, n)
+    Ar = spzeros(T, n, n)
+
+    if dc[1] != zero(T); Al[1, 1] = dc[1]; end
+    if dc[2] != zero(T); Ar[end, end] = dc[2]; end
+
+    Bl = spzeros(T, n, m + 1)
+    Br = spzeros(T, n, m + 1)
+
+    Gl = grad(k, m, dx)
+    Gr = grad(k, m, dx)
+
+    if nc[1] != zero(T); Bl[1, 1] = -nc[1]; end
+    if nc[2] != zero(T); Br[end, end] =  nc[2]; end
+
+    return Al + Bl * Gl, Ar + Br * Gr
+end
+
+"""
+    Internal helper: overwrite RHS at boundary indices.
+"""
+@inline function _scalarbc_rhs!(b, vec::NTuple{2,Int}, v::NTuple{2,T}) where {T}
+    b[vec[1]] = v[1]
+    b[vec[2]] = v[2]
+    return b
+end
+
+"""
+    1D BC applicator. Mirrors MATLAB addScalarBC1D.
+    Signature keeps the discretization params (`k,m,dx`) separate from `bc`.
+"""
+function addScalarBC!(A::SparseMatrixCSC, b::AbstractVector, bc::ScalarBC1D{T},
+                      k::Integer, m::Integer, dx) where {T}
+
+    dc, nc, v = bc.dc, bc.nc, bc.v
+
+    # Equivalent of MATLAB: q = find(dc.^2 + nc.^2, 1)
+    hasbc = (dc[1] != zero(T)) || (dc[2] != zero(T)) || (nc[1] != zero(T)) || (nc[2] != zero(T))
+    if !hasbc
+        return A, b
+    end
+
+    vec = (1, size(A, 1))
+
+    # Zero-out first and last rows of A (sparse-friendly approach)
+    # We remove the existing nonzeros in those rows.
+    sub = A[[vec[1], vec[2]], :]
+    rows, cols, vals = findnz(sub)  # rows are 1..2 in the submatrix
+    A .-= sparse((rows .== 1) .* vec[1] .+ (rows .== 2) .* vec[2], cols, vals, size(A,1), size(A,2))
+
+    # Zero out boundary entries of b
+    b[vec[1]] = zero(eltype(b))
+    b[vec[2]] = zero(eltype(b))
+
+    # Add BC LHS
+    Al, Ar = _scalarbc1d_lhs(k, m, dx, dc, nc)
+    A .+= (Al .+ Ar)
+
+    # Set BC RHS
+    _scalarbc_rhs!(b, vec, v)
+
+    return A, b
+end
+
+
+# -------------------------
+# Construction helpers
+# -------------------------
+
+"""
+    Convenience constructor from vectors/tuples.
+    Accepts 2-element vectors too.
+"""
+ScalarBC1D(dc, nc, v) = ScalarBC1D(tuple(dc...), tuple(nc...), tuple(v...))

--- a/julia/MOLE.jl/test/BCs/scalarBC.jl
+++ b/julia/MOLE.jl/test/BCs/scalarBC.jl
@@ -1,0 +1,145 @@
+@testset "addScalarBC! (1D) tests" begin
+
+    @testset "no BCs test" begin
+        # Problem size
+        m  = 8
+        n  = m + 2
+        k  = 2
+        dx = 0.1
+
+        # Nontrivial sparse A and b
+        A_dense = reshape(collect(1.0:(n*n)), n, n) ./ 13.0
+        A = sparse(A_dense)
+        b = collect(1.0:n) ./ 7.0
+
+        dc0 = (0.0, 0.0)
+        nc0 = (0.0, 0.0)
+        v0  = (9.0, 9.0)  # required by ScalarBC1D even if unused
+        bc0 = BCs.ScalarBC1D(dc0, nc0, v0)
+
+        A2, b2 = BCs.addScalarBC!(A, b, bc0, k, m, dx)
+
+        # No BCs leave the systems unchanged
+        @test A2 == A
+        @test b2 == b
+    end
+
+    @testset "Dirichlet/Neumann BC with grad and dense matrix reference" begin
+        # Problem size
+        m  = 8
+        n  = m + 2
+        k  = 2
+        dx = 0.1
+
+        # Nontrivial sparse A and b
+        A_dense = reshape(collect(1.0:(n*n)), n, n) ./ 13.0
+        A = sparse(A_dense)
+        b = collect(1.0:n) ./ 7.0
+
+        dc = (2.0, 3.0)
+        nc = (4.0, 5.0)
+        v  = (7.0, 8.0)
+        bc = BCs.ScalarBC1D(dc, nc, v)
+
+        A2, b2 = BCs.addScalarBC!(A, b, bc, k, m, dx)
+
+        # ---- expected reference (dense build, but no requirement that result is dense) ----
+        A_ref = copy(A_dense)
+        b_ref = copy(b)
+
+        # zero boundary rows and boundary RHS entries
+        A_ref[1, :] .= 0.0
+        A_ref[end, :] .= 0.0
+        b_ref[1] = 0.0
+        b_ref[end] = 0.0
+
+        Gl = Matrix(Operators.grad(k, m, dx))
+        Gr = Matrix(Operators.grad(k, m, dx))
+
+        Al = zeros(Float64, n, n)
+        Ar = zeros(Float64, n, n)
+        Al[1, 1] = dc[1]
+        Ar[end, end] = dc[2]
+
+        Bl = zeros(Float64, n, m + 1)
+        Br = zeros(Float64, n, m + 1)
+        Bl[1, 1] = -nc[1]
+        Br[end, end] =  nc[2]
+
+        A_ref .+= (Al + Bl * Gl) .+ (Ar + Br * Gr)
+
+        # overwrite boundary RHS values
+        b_ref[1] = v[1]
+        b_ref[end] = v[2]
+
+        @test isapprox(norm(A2 - sparse(A_ref)), 0.0; rtol=1e-12, atol=1e-12)
+        @test isapprox(norm(b2 - b_ref), 0.0; rtol=1e-12, atol=1e-12)
+    end
+
+    @testset "Dirichlet/Neumann BC with sparse format reference" begin
+        # Problem size
+        m  = 8
+        n  = m + 2
+        k  = 2
+        dx = 0.1
+
+        # Nontrivial sparse A and b
+        A_dense = reshape(collect(1.0:(n*n)), n, n) ./ 13.0
+        A = sparse(A_dense)
+        b = collect(1.0:n) ./ 7.0
+
+        dc = (2.0, 3.0)
+        nc = (4.0, 5.0)
+        v  = (7.0, 8.0)
+        bc = BCs.ScalarBC1D(dc, nc, v)
+
+        A2, b2 = BCs.addScalarBC!(A, b, bc, k, m, dx)
+
+        @test A2 isa SparseMatrixCSC
+
+        vec = (1, n)
+
+        # reference sparse matrix
+        A_ref = sparse(A)  # copy
+
+        # remove existing first+last rows (set to zero) by subtracting their nonzeros
+        sub = A_ref[[vec[1], vec[2]], :]
+        rows, cols, vals = findnz(sub)
+
+        mapped_rows = similar(rows)
+        @inbounds for i in eachindex(rows)
+            mapped_rows[i] = (rows[i] == 1) ? vec[1] : vec[2]
+        end
+
+        A_ref .-= sparse(mapped_rows, cols, vals, n, n)
+
+        # RHS boundary handling
+        b_ref = copy(b)
+        b_ref[vec[1]] = 0.0
+        b_ref[vec[2]] = 0.0
+
+        # LHS BC contributions (sparse)
+        Gl = sparse(Operators.grad(k, m, dx))
+        Gr = sparse(Operators.grad(k, m, dx))
+
+        Al = spzeros(Float64, n, n)
+        Ar = spzeros(Float64, n, n)
+        Al[1, 1] = dc[1]
+        Ar[end, end] = dc[2]
+
+        Bl = spzeros(Float64, n, m + 1)
+        Br = spzeros(Float64, n, m + 1)
+        Bl[1, 1] = -nc[1]
+        Br[end, end] =  nc[2]
+
+        A_ref .+= (Al + Bl * Gl) .+ (Ar + Br * Gr)
+
+        b_ref[vec[1]] = v[1]
+        b_ref[vec[2]] = v[2]
+
+        # pure sparse comparisons
+        @test norm(A2 - A_ref) ≤ 1e-12
+        @test norm(b2 - b_ref) ≤ 1e-12
+    end
+
+end

--- a/julia/MOLE.jl/test/Project.toml
+++ b/julia/MOLE.jl/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/julia/MOLE.jl/test/runtests.jl
+++ b/julia/MOLE.jl/test/runtests.jl
@@ -1,6 +1,6 @@
 using MOLE
-using Test, LinearAlgebra
-import MOLE: Operators
+using Test, LinearAlgebra, SparseArrays
+import MOLE: Operators, BCs
 
 @testset "Testing MOLE operators" begin
     @testset "Testing 1D divergence" begin
@@ -13,5 +13,12 @@ import MOLE: Operators
 
     @testset "Testing 1D laplacian" begin
         include("Operators/laplacian.jl")
+    end
+end
+
+@testset "Testing Boundary Conditions" begin
+    
+    @testset "Test addScalarBC" begin
+        include("BCs/scalarBC.jl")
     end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description

This PR adds a new set of Boundary Conditions in Julia. Specifically, it adds:
- the `AbstractScalarBC` abstract type (so that we can generalize to multiple dimensions later)
-  the `ScalarBC1D` concrete type and convenience constructor
- a couple of helper functions
- the `addScalarBC!` functions to apply the scalar type BCs
- unit tests for this type of BCs (not present in the MATLAB/Octave counterpart)
- translation of the `elliptic1DaddScalarBC.m` example as `elliptic1DaddScalarBC.jl`

## Related Issues & Documents


- [x] I have created an Issue that is paired with this PR
- Closes #299 

## QA Instructions, Screenshots, Recordings

## Added/updated tests?
We encourage you to test all code included with MOLE, including examples.

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [x] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md

