### PR TITLE
Fix error calculation in MATLAB_Octave tutorial

### DIFF
--- a/examples/matlab_octave/tutorials/two_way_wave_equation/comparison_two_way_wave_md_vs_fd.m
+++ b/examples/matlab_octave/tutorials/two_way_wave_equation/comparison_two_way_wave_md_vs_fd.m
@@ -130,7 +130,8 @@ loglog(1 ./ num_cells, error_md, 'LineWidth', 2)
 xlim([1 / num_cells(end) 1 / num_cells(1)]);
 xlabel('dx'); ylabel('error');
 grid on;
-title(['Error: FD slope~', num2str(p_fd(1)), ', MD slope~', num2str(p_md(1))]);
+title(['Error Convergence, FD slope=', num2str(p_fd(1),'%.2f'), ...
+       ', MD slope=', num2str(p_md(1),'%.2f')]);
 legend('FD Error','MD error')
 set(gca, "linewidth", 2, "fontsize", 16)
 
@@ -143,7 +144,7 @@ xlim([num_cells(1) num_cells(end)]);
 ylim([min( min(walltime_fd), min(walltime_md) )  max( max(walltime_fd), max(walltime_md) )]);
 xlabel('num points'); ylabel('walltime [s]');
 grid on;
-title(['Walltime, MD is order ', num2str(k)]);
+title(['Walltime: FD (order 2) vs MD (order ', num2str(k), ')']);
 legend('FD time', 'MD time');
 set(gca, "linewidth", 2, "fontsize", 16)
 
@@ -155,7 +156,7 @@ loglog(num_cells, flops_md, 'LineWidth', 2);
 xlim([ num_cells(1) num_cells(end) ]); ylim([ 1e5 1e8 ]);
 xlabel('num cells'); ylabel('FLOPs');
 grid on;
-title(['FLOPs for each method, mimetic order:', num2str(k)]);
+title(['FLOPs: FD (order 2) vs MD (order ', num2str(k), ')']);
 legend('FD FLOPs', 'MD FLOPs');
 set(gca, "linewidth", 2, "fontsize", 16)
 

--- a/examples/matlab_octave/tutorials/two_way_wave_equation/comparison_two_way_wave_md_vs_fd.m
+++ b/examples/matlab_octave/tutorials/two_way_wave_equation/comparison_two_way_wave_md_vs_fd.m
@@ -100,13 +100,14 @@ k    = 2;        % Mimetic Order of Accuracy, can change to 4,6,8
 c    = 0.1;      % Velocity, 1 makes FD sceme exact
 west = -2.0;     % Domain's leftmost limits
 east = 2.0;      % Domain's rightmost limit
+dt   = 0.001;    % Time step, must work for all cell sizes
 
 % Number of cells to try, points is cells+1
-num_cells = [ 10, 20, 40, 80, 160 ];
+num_cells = [ 20, 40, 80, 160 ];
 
 %% Run each of the methods over the different grids
-[ U2_fd, error_fd, walltime_fd, flops_fd ] = finite_diff_two_way_wave_eq();
-[ U2_md, error_md, walltime_md, flops_md ] = mimetic_diff_two_way_wave_eq();
+[ U2_fd, error_fd, walltime_fd, flops_fd ] = finite_diff_two_way_wave_eq(c, dt, num_cells);
+[ U2_md, error_md, walltime_md, flops_md ] = mimetic_diff_two_way_wave_eq(k, c, dt, num_cells);
 
 %% Error analysis
 

--- a/examples/matlab_octave/tutorials/two_way_wave_equation/finite_diff_two_way_wave_eq.m
+++ b/examples/matlab_octave/tutorials/two_way_wave_equation/finite_diff_two_way_wave_eq.m
@@ -52,8 +52,7 @@ error_fd = zeros(size(num_cells));
 walltime_fd = zeros(size(num_cells));
 flops_fd = zeros(size(num_cells));
 
-% Initial Condition Function (One smooth, one smoother)
-f = @(x) ( (x > -0.5) & (x < 0.5) ) .* (cos(pi * x).^2);
+% Initial Condition Function
 f = @(x) exp( -x.^2 / 0.1 );
 
 % Wave solution using d'Alembert

--- a/examples/matlab_octave/tutorials/two_way_wave_equation/finite_diff_two_way_wave_eq.m
+++ b/examples/matlab_octave/tutorials/two_way_wave_equation/finite_diff_two_way_wave_eq.m
@@ -1,4 +1,4 @@
-function [ U2_fd, error_fd, walltime_fd, flops_fd ] = finite_diff_two_way_wave_eq()
+function [ U2_fd, error_fd, walltime_fd, flops_fd ] = finite_diff_two_way_wave_eq(c, dt, num_cells)
 %% FINITE_DIFF_TWO_WAY_WAVE_EQ
 %  Solve the 1D two-way wave equation using standard finite differences.
 %
@@ -11,6 +11,11 @@ function [ U2_fd, error_fd, walltime_fd, flops_fd ] = finite_diff_two_way_wave_e
 %  where D_fd is the standard second-derivative finite-difference matrix:
 %
 %      D_fd = (1/dx^2) * tridiag([1, -2, 1])
+%
+%  INPUTS:
+%    c           - wave speed
+%    dt          - time step
+%    num_cells   - array of number of cells to test.
 %
 %  OUTPUTS:
 %    U2_fd       - Final solution vector at last time step
@@ -39,20 +44,17 @@ function [ U2_fd, error_fd, walltime_fd, flops_fd ] = finite_diff_two_way_wave_e
 %
 
 %% Problem definition
-c    = 0.1;      % Velocity, 1 makes FD scheme exact
 west = -2.0;     % Domain's leftmost limits
 east = 2.0;      % Domain's rightmost limit
-
-%% Number of cells to try, grid points is cells+1
-num_cells = [ 10, 20, 40, 80, 160 ];
 
 % generic holders for metrics within the loops
 error_fd = zeros(size(num_cells));
 walltime_fd = zeros(size(num_cells));
 flops_fd = zeros(size(num_cells));
 
-% Initial Condition Function
+% Initial Condition Function (One smooth, one smoother)
 f = @(x) ( (x > -0.5) & (x < 0.5) ) .* (cos(pi * x).^2);
+f = @(x) exp( -x.^2 / 0.1 );
 
 % Wave solution using d'Alembert
 u = @(x,t) 0.5 * ( f(x - c * t) + f(x + c * t) );
@@ -64,7 +66,6 @@ for cell_index = 1 : numel(num_cells)
     nx = m+1;                       % number of grid points
 
     dx = (east - west) / m;         % spacial discretization
-    dt = 0.001;                     % Time step constant for error analysis
 
     r2_fd = c^2 * (dt^2 / dx^2);    % c in the equation
 
@@ -126,7 +127,8 @@ for cell_index = 1 : numel(num_cells)
 
     % Number of flops
     flops_fd(cell_index) = (2 * nnz_fd + length(U0_fd)) * t;
-    error_fd(cell_index) = max(U2_fd-analytic_fd);
+    diff = U2_fd - analytic_fd;
+    error_fd(cell_index) = norm(diff) / norm(analytic_fd);
 
 end
 

--- a/examples/matlab_octave/tutorials/two_way_wave_equation/mimetic_diff_two_way_wave_eq.m
+++ b/examples/matlab_octave/tutorials/two_way_wave_equation/mimetic_diff_two_way_wave_eq.m
@@ -57,8 +57,7 @@ error_md = zeros(size(num_cells));
 walltime_md = zeros(size(num_cells));
 flops_md = zeros(size(num_cells));
 
-% Initial Condition Function (One smooth, one smoother)
-f = @(x) ( (x > -0.5) & (x < 0.5) ) .* (cos(pi * x).^2);
+% Initial Condition Function
 f = @(x) exp( -x.^2 / 0.1 );
 
 % Wave solution using d'Almbert

--- a/examples/matlab_octave/tutorials/two_way_wave_equation/mimetic_diff_two_way_wave_eq.m
+++ b/examples/matlab_octave/tutorials/two_way_wave_equation/mimetic_diff_two_way_wave_eq.m
@@ -1,4 +1,4 @@
-function [ U2_md, error_md, walltime_md, flops_md ] = mimetic_diff_two_way_wave_eq()
+function [ U2_md, error_md, walltime_md, flops_md ] = mimetic_diff_two_way_wave_eq(k, c, dt, num_cells)
 %% MIMETIC_DIFF_TWO_WAY_WAVE_EQ
 %  Solve the 1D two-way wave equation using mimetic finite differences.
 %
@@ -10,6 +10,12 @@ function [ U2_md, error_md, walltime_md, flops_md ] = mimetic_diff_two_way_wave_
 %      U^{n+1} = 2*U^{n} - U^{n-1} + (c^2 * dt^2 * L) * U^{n}
 %  where L is the mimetic discrete Laplacian operator. Note there is no spacial
 %  discretization, the L takes care of that.
+%
+%  INPUTS:
+%    k           - mimetic order of accuracy (2,4,6,8)
+%    c           - wave speed
+%    dt          - time step
+%    num_cells   - array of number of cells to test.
 %
 %  OUTPUTS:
 %    U2_md       - Final solution vector at last time step
@@ -43,21 +49,17 @@ function [ U2_md, error_md, walltime_md, flops_md ] = mimetic_diff_two_way_wave_
 %
 
 %% Problem definition
-k    = 2;        % Mimetic Order of Accuracy, can change to 4,6,8
-c    = 0.1;      % Velocity, 1 makes FD sceme exact
 west = -2.0;     % Domain's leftmost limits
 east = 2.0;      % Domain's rightmost limit
-
-%% Number of cells to try, points is cells+1
-num_cells = [ 10, 20, 40, 80, 160 ];
 
 % generic holders for loop info
 error_md = zeros(size(num_cells));
 walltime_md = zeros(size(num_cells));
 flops_md = zeros(size(num_cells));
 
-% Initial Condition Function
+% Initial Condition Function (One smooth, one smoother)
 f = @(x) ( (x > -0.5) & (x < 0.5) ) .* (cos(pi * x).^2);
+f = @(x) exp( -x.^2 / 0.1 );
 
 % Wave solution using d'Almbert
 u = @(x,t) 0.5 * ( f(x - c * t) + f(x + c * t) );
@@ -69,7 +71,6 @@ for cell_index = 1 : numel(num_cells)
     nx = m+1;                       % number of grid points
 
     dx = (east - west) / m;         % spacial discretization
-    dt = 0.001;                     % Time step constant for error analysis
 
     r2_md = c^2 * (dt^2);           % c in the equation, dx is built into the
                                     % mimetic operator Laplacian (L)
@@ -108,6 +109,7 @@ for cell_index = 1 : numel(num_cells)
 
     % Number of flops
     flops_md(cell_index) = (2 * nnz_md + (3 * length(U0_md)) ) * t;
-    error_md(cell_index) = max(U2_md-analytic_md);
+    diff = U2_md - analytic_md;
+    error_md(cell_index) = norm(diff) / norm(analytic_md);
 
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
Fixes the bug in the MATLAB/Octave tutorial where changing the order of accuracy of the mimetic operator does nothing. The errors calculated are essentially the same regardless of order of accuracy.

## Related Issues & Documents
- [X] I have created an Issue that is paired with this PR
- Closes #349 

## QA Instructions, Screenshots, Recordings
<img width="1116" height="504" alt="image" src="https://github.com/user-attachments/assets/f1529212-03cc-4480-8ac3-c6ab8fe90b5d" />

<img width="1108" height="505" alt="image" src="https://github.com/user-attachments/assets/c811db03-4c45-41a0-8f13-3f372c61d6dc" />

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: tutorial not a test.
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [X] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [X] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md


## What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTRyazY3NWlrNHR5M2FpaTU0NXBhdGJ0aXZ2d2VsZTdpMGNnYmU1NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/11Wkoq2MaUbLXi/giphy.gif" width="100" height="100" />
