### PR TITLE
Corrections for bug issue: MATLAB Tests are not running #361

### DIFF
--- a/tests/matlab_octave/CMakeLists.txt
+++ b/tests/matlab_octave/CMakeLists.txt
@@ -13,7 +13,7 @@ foreach(TEST_SOURCE ${TEST_SOURCES})
         COMMAND matlab
           -nojvm
           -batch
-          "addpath('${CMAKE_CURRENT_SOURCE_DIR}'); assertSuccess(runtests('${TEST_NAME}'))"
+          "addpath('${CMAKE_CURRENT_SOURCE_DIR}'); addpath('${CMAKE_SOURCE_DIR}/src/matlab_octave'); assertSuccess(runtests('${TEST_NAME}'))"
     )
 endforeach()
 

--- a/tests/matlab_octave/testPoissonAccuracy.m
+++ b/tests/matlab_octave/testPoissonAccuracy.m
@@ -1,7 +1,6 @@
 classdef testPoissonAccuracy < matlab.unittest.TestCase
     methods(Test)
         function testforEnergy(testCase)
-            addpath ('../../src/matlab_octave')
             
             west = 0;  % Domain's limits
 	    east = 1;


### PR DESCRIPTION
<!--
     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
     - 📖 Read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
     - 📝 Add license information in the appropriate place. See MATLAB or C++ code for reference.
      
          SPDX-License-Identifier: GPL-3.0-or-later
          © 2008-2024 San Diego State University Research Foundation (SDSURF).
          See LICENSE file or https://www.gnu.org/licenses/gpl-3.0.html for details. 

     NOTE: Pull Requests from forked repositories need to be reviewed by
     a MOLE Team member before any CI builds will run.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ X ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description

Needed addition of

  addpath('${CMAKE_SOURCE_DIR}/src/matlab_octave');

in tests/matlab_octave/CMakeLists.txt for MATLAB test runner to execute properly.

## Related Issues & Documents

<!--
For Pull Requests that relate or close an Issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [ x ] I have created an Issue that is paired with this PR
- Closes #361

## QA Instructions, Screenshots, Recordings

From the mole/build subdirectory, invoke the following: make run_matlab_octave_tests

paolini@dgx:~/mole/build$ make run_matlab_octave_tests
[100%] Running all MATLAB/Octave unit tests...
Test project /home/paolini/mole/build/tests/matlab_octave
      Start  1: testAddScalarBC
 1/10 Test  #1: testAddScalarBC ..................   Passed   16.49 sec
      Start  2: testBCConsistency
 2/10 Test  #2: testBCConsistency ................   Passed   16.57 sec
      Start  3: testDivPolynomial
 3/10 Test  #3: testDivPolynomial ................   Passed   16.49 sec
      Start  4: testDivergence
 4/10 Test  #4: testDivergence ...................   Passed   16.14 sec
      Start  5: testEnergy
 5/10 Test  #5: testEnergy .......................   Passed   16.79 sec
      Start  6: testGradPolynomial
 6/10 Test  #6: testGradPolynomial ...............   Passed   17.12 sec
      Start  7: testGradient
 7/10 Test  #7: testGradient .....................   Passed   16.65 sec
      Start  8: testLapPolynomial
 8/10 Test  #8: testLapPolynomial ................   Passed   16.76 sec
      Start  9: testLaplacian
 9/10 Test  #9: testLaplacian ....................   Passed   16.36 sec
      Start 10: testPoissonAccuracy
10/10 Test #10: testPoissonAccuracy ..............***Failed   17.05 sec
Running testPoissonAccuracy

================================================================================
Verification failed in testPoissonAccuracy/testforEnergy.
    ----------------
    Test Diagnostic:
    ----------------
    Test failed for k = 8
    ---------------------
    Framework Diagnostic:
    ---------------------
    verifyGreaterThan failed.
    --> The value must be greater than the minimum value.

    Actual Value:
      -1.597500939585466
    Minimum Value (Exclusive):
       7.500000000000000
    ------------------
    Stack Information:
    ------------------
    In /home/paolini/mole/tests/matlab_octave/testPoissonAccuracy.m (testPoissonAccuracy.testforEnergy) at 48
================================================================================
.
Done testPoissonAccuracy
__________

Failure Summary:

     Name                               Failed  Incomplete  Reason(s)
    ================================================================================
     testPoissonAccuracy/testforEnergy    X                 Failed by verification.
Error using matlab.unittest.internal.BaseTestResult/assertSuccess (line 125)
At least one test failed in the test session.



90% tests passed, 1 tests failed out of 10

Total Test time (real) = 166.42 sec

The following tests FAILED:
         10 - testPoissonAccuracy (Failed)

Tested under Ubuntu 20.04.4 LTS with MATLAB R2021b

## Keep-open request

- [ ] I am requesting maintainer review for `keep-open`.

Reason:

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ X ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [ X ] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [ X ] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://miro.medium.com/v2/1*VpQb2kbPdj6vXH2pJqi7Qg.gif" width="100" height="100" />
