### PR TITLE
Reorganize MOLE.jl docs Examples directory in categories

### DIFF
--- a/julia/MOLE.jl/docs/make.jl
+++ b/julia/MOLE.jl/docs/make.jl
@@ -2,8 +2,42 @@ push!(LOAD_PATH,"../src/")
 using Documenter, MOLE, SparseArrays
 
 makedocs(
-    sitename="MOLE.jl Docs",
+    sitename = "MOLE.jl Docs",
     pages = [
-        "Home" => "index.md"
-    ]
+        "Home" => "index.md",
+        "Examples" => [
+            "Overview" => "examples/index.md",
+            "Elliptic Problems" => [
+                "Overview" => "examples/Elliptic/index.md",
+                "1D Elliptic Problems" => [
+                    "Overview" => "examples/Elliptic/1D/index.md",
+                    "Elliptic 1D" => "examples/Elliptic/1D/Elliptic1D.md",
+                    "Elliptic 1D Add Scalar Boundary Conditions" =>
+                        "examples/Elliptic/1D/Elliptic1D-add-Scalar-BC.md",
+                ],
+                "2D Elliptic Problems" => [
+                    "Overview" => "examples/Elliptic/2D/index.md",
+                    "X Dirichlet Y Dirichlet" =>
+                        "examples/Elliptic/2D/Elliptic2D-X-Dirichlet-Y-Dirichlet.md",
+                    "X Periodic Y Dirichlet" =>
+                        "examples/Elliptic/2D/Elliptic2D-X-Periodic-Y-Dirichlet.md",
+                ],
+            ],
+            "Hyperbolic Problems" => [
+                "Overview" => "examples/Hyperbolic/index.md",
+                "1D Hyperbolic Problems" => [
+                    "Overview" => "examples/Hyperbolic/1D/index.md",
+                    "Hyperbolic 1D" => "examples/Hyperbolic/1D/Hyperbolic1D.md",
+                    "Burgers 1D" => "examples/Hyperbolic/1D/Burgers1D.md",
+                ],
+            ],
+            "Parabolic Problems" => [
+                "Overview" => "examples/Parabolic/index.md",
+                "2D Parabolic Problems" => [
+                    "Overview" => "examples/Parabolic/2D/index.md",
+                    "Parabolic 2D" => "examples/Parabolic/2D/Parabolic2D.md",
+                ],
+            ],
+        ],
+    ],
 )

--- a/julia/MOLE.jl/docs/src/examples/Elliptic/1D/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Elliptic/1D/index.md
@@ -2,9 +2,7 @@
 
 These examples demonstrate the solution of elliptic equations in one dimension, including boundary value problems and various solution methods.
 
-```@contents
-:maxdepth: 1
+## Available Examples
 
-Elliptic1D
-Elliptic1D-add-Scalar-BC
-```
+- [Elliptic 1D](Elliptic1D.md)
+- [Elliptic1D Add Scalar Boundary Conditions](Elliptic1D-add-Scalar-BC.md)

--- a/julia/MOLE.jl/docs/src/examples/Elliptic/2D/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Elliptic/2D/index.md
@@ -2,9 +2,7 @@
 
 These examples cover two-dimensional elliptic partial differential equations.
 
-```@contents
-:maxdepth: 1
+## Available Examples
 
-Elliptic2D-X-Dirichlet-Y-Dirichlet
-Elliptic2D-X-Periodic-Y-Dirichlet
-```
+- [Elliptic2D X Dirichlet Y Dirichlet](Elliptic2D-X-Dirichlet-Y-Dirichlet.md)
+- [Elliptic2D X Periodic Y Dirichlet](Elliptic2D-X-Periodic-Y-Dirichlet.md)

--- a/julia/MOLE.jl/docs/src/examples/Elliptic/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Elliptic/index.md
@@ -2,10 +2,12 @@
 
 Elliptic partial differential equations are used to model steady-state phenomena with no time dependence. Common examples include the Poisson equation and Laplace equation, which describe electrostatic potentials, steady-state heat distribution, and equilibrium fluid flow.
 
-```@contents
-:maxdepth: 2
-:caption: Contents
+## Available Examples
 
-1D/index
-2D/index
-```
+- [1D Elliptic Problems](1D/index.md)
+  - [Elliptic 1D](1D/Elliptic1D.md)
+  - [Elliptic1D Add Scalar Boundary Conditions](1D/Elliptic1D-add-Scalar-BC.md)
+
+- [2D Elliptic Problems](2D/index.md)
+  - [Elliptic2D X Dirichlet Y Dirichlet](2D/Elliptic2D-X-Dirichlet-Y-Dirichlet.md)
+  - [Elliptic2D X Periodic Y Dirichlet](2D/Elliptic2D-X-Periodic-Y-Dirichlet.md)

--- a/julia/MOLE.jl/docs/src/examples/Hyperbolic/1D/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Hyperbolic/1D/index.md
@@ -2,9 +2,7 @@
 
 These examples demonstrate the solution of hyperbolic equations in one dimension.
 
-```@contents
-:maxdepth: 1
+## Available Examples
 
-Hyperbolic1D
-Burgers1D
-``` 
+- [Hyperbolic 1D](Hyperbolic1D.md)
+- [Burgers 1D](Burgers1D.md)

--- a/julia/MOLE.jl/docs/src/examples/Hyperbolic/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Hyperbolic/index.md
@@ -2,10 +2,8 @@
 
 Hyperbolic partial differential equations model wave propagation and transport phenomena where information travels along characteristic curves. Examples include the wave equation, transport equation, and conservation laws such as Burgers' equation.
 
-```@content
-:maxdepth: 2
-:caption: Contents
+## Available Examples
 
-1D/index
-```
-
+- [1D Hyperbolic Problems](1D/index.md)
+  - [Hyperbolic 1D](1D/Hyperbolic1D.md)
+  - [Burgers 1D](1D/Burgers1D.md)

--- a/julia/MOLE.jl/docs/src/examples/Parabolic/2D/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Parabolic/2D/index.md
@@ -2,8 +2,6 @@
 
 These examples cover two-dimensional parabolic partial differential equations.
 
-```@contents
-:maxdepth: 1
+## Available Examples
 
-Parabolic2D
-```
+- [Parabolic2D](Parabolic2D.md)

--- a/julia/MOLE.jl/docs/src/examples/Parabolic/index.md
+++ b/julia/MOLE.jl/docs/src/examples/Parabolic/index.md
@@ -2,9 +2,7 @@
 
 Parabolic partial differential equations describe diffusion processes where initial discontinuities are immediately smoothed out. The heat equation is a classic example, modeling how temperature distributes over time in a medium.
 
-```@contents
-:maxdepth: 2
-:caption: Contents
+## Available Examples
 
-2D/index
-```
+- [2D Parabolic Problems](2D/index.md)
+  - [Parabolic 2D](2D/Parabolic2D.md)

--- a/julia/MOLE.jl/docs/src/examples/index.md
+++ b/julia/MOLE.jl/docs/src/examples/index.md
@@ -5,13 +5,24 @@ The MOLE library contains many examples written in OCTAVE/MATLAB, C++, and Julia
 **NOTE:**
 The name for OCTAVE/MATLAB, C++, and Julia will be the same (i.e., the files `elliptic1D.m`, `elliptic1D.cpp`, and `elliptic1D.jl` solve the same differential equation explained here under Elliptic1D). These examples are only the ones implemented in Julia. There are many more OCTAVE/MATLAB and C++ examples, which can be found in the main MOLE documentation.
 
-```@contents
-:maxdepth: 1
-:caption: "Examples by Category"
+## Elliptic Problems
 
-src/examples/Elliptic/index
-src/examples/Parabolic/index
-src/examples/Hyperbolic/index
-```
+- [1D Elliptic Problems](Elliptic/1D/index.md)
+  - [Elliptic 1D](Elliptic/1D/Elliptic1D.md)
+  - [Elliptic1D Add Scalar Boundary Conditions](Elliptic/1D/Elliptic1D-add-Scalar-BC.md)
+- [2D Elliptic Problems](Elliptic/2D/index.md)
+  - [Elliptic2D X Dirichlet Y Dirichlet](Elliptic/2D/Elliptic2D-X-Dirichlet-Y-Dirichlet.md)
+  - [Elliptic2D X Periodic Y Dirichlet](Elliptic/2D/Elliptic2D-X-Periodic-Y-Dirichlet.md)
 
-More examples will be added in the future.
+## Hyperbolic Problems
+
+- [1D Hyperbolic Problems](Hyperbolic/1D/index.md)
+  - [Hyperbolic 1D](Hyperbolic/1D/Hyperbolic1D.md)
+  - [Burgers 1D](Hyperbolic/1D/Burgers1D.md)
+
+## Parabolic Problems
+
+- [2D Parabolic Problems](Parabolic/2D/index.md)
+  - [Parabolic2D](Parabolic/2D/Parabolic2D.md)
+
+  More examples will be added in the future.


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [x] Documentation

## Description
The old way the MOLE.jl documentation was structured, did not categorize the Examples section as the base language(s) do. It created a flat TOC for the Examples. See the following screenshot of the old preview:

<img width="1721" height="1620" alt="Screenshot from 2026-06-16 12-43-57" src="https://github.com/user-attachments/assets/550e9751-193b-4687-a59d-9c90ce2bb1ca" />

With this fix, here is how the preview looks like

<img width="2437" height="1444" alt="Screenshot from 2026-06-24 10-05-23" src="https://github.com/user-attachments/assets/3a828f62-ecfa-467c-b569-e7b052b5bc8e" />

And, when you click on one of the sub-categories here is how one of the examples documentation looks like:

<img width="2428" height="2222" alt="Screenshot from 2026-06-24 10-05-14" src="https://github.com/user-attachments/assets/f4eebefd-1ed3-4480-b9b4-6ebcbaed5ba5" />



## Related Issues & Documents

- [x] I have created an Issue that is paired with this PR
- Closes #383 

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [x] No, and this is why: N/A
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [x] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md

