### PR TITLE
Add CodeCov to track code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,46 @@
+codecov:
+  branch: main
+
+comment:
+  layout: "header, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "docs/**"
+  - "doc/**"
+  - "examples/**"
+  - "**/examples/**"
+  - "**/test/**"
+  - "**/tests/**"
+  - "julia/MOLE.jl/docs/**"
+  - "julia/MOLE.jl/examples/**"
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default: off
+
+      julia:
+        flags:
+          - julia
+        target: auto
+        threshold: 1%
+
+    patch:
+      default: off
+
+      julia:
+        flags:
+          - julia
+        target: 80%
+        threshold: 5%
+
+flags:
+  julia:
+    paths:
+      - julia/MOLE.jl/src/


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

This PR adds a `.codecov.yml` file to be used to track Code Coverage analytics (i.e., the percentage of source code that is exercised by unit tests). This is an important metric for code quality assurance.

For now, I only added the tag specific to the MOLE.jl Julia implementation, as that is the one that I am currently work on and can test. Follow-up development can add the tags for the other language implementations as developers desire.

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
Added a `.codecov.yml` file. 

## Related Issues & Documents

- [x] I have created an Issue that is paired with this PR
- Closes #390 

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [x] No, and this is why: N/A
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [x] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md


