### PR TITLE
MOLE.jl docs: use deploy_repo

### DIFF
--- a/julia/MOLE.jl/docs/make.jl
+++ b/julia/MOLE.jl/docs/make.jl
@@ -40,7 +40,8 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/csrc-sdsu/MOLE.jl-docs.git",
+    repo = "github.com/csrc-sdsu/mole.git",
+    deploy_repo = "github.com/csrc-sdsu/MOLE.jl-docs.git",
     devbranch = "main",
     push_preview = true,
 )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [x] Documentation

## Description
This PR adds the `deploy_repo` argument to `deploydocs`. This is the new recommended way to manage out-of-repo deployment according to Documenter.jl's [docs](https://documenter.juliadocs.org/stable/man/hosting/#Out-of-repo-deployment).

## Related Issues & Documents

- [x] I have created an Issue that is paired with this PR
- Closes #399 

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [x] No, and this is why: N/A
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [x] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md
