### PR TITLE
Add a link to MOLE.jl Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-MOLE is a high-quality (C++ & MATLAB/Octave) library that implements
+MOLE is a high-quality (C++, MATLAB/Octave, and Julia) library that implements
 high-order mimetic operators to solve partial differential equations.
 It provides discrete analogs of the most common vector calculus operators:
 Gradient, Divergence, Laplacian, Bilaplacian, and Curl. These operators (highly sparse matrices) act
@@ -139,11 +139,15 @@ and on Windows downlaoding and running the file from [here](https://sourceforge.
 
 ### C++
 
-Four self-contained, well-documented examples demonstrating typical PDE solutions. These are automatically built with `make` and serve as an excellent starting point for C++ users.
+There are several self-contained, well-documented examples demonstrating typical PDE solutions. These are automatically built with `make` and serve as an excellent starting point for C++ users.
 
 ### MATLAB/Octave Examples
 
 A collection of over 30 examples showcasing various PDE solutions, from simple linear one-dimensional problems to complex nonlinear multidimensional scenarios.
+
+### Julia Examples
+
+Several self-contained, well-documented examples demostrate the MOLE.jl use. Their documentation can be found in the [MOLE.jl Documentation website Examples section](https://www.mole-ose.org/MOLE.jl-docs/dev/examples/).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ MOLE comes with comprehensive documentation:
 
 - **API Reference & User Guide**: Access our online [Documentation](https://mole-docs.readthedocs.io/en/latest/)
 - **Building Documentation**: To build documentation locally, follow our [Documentation Guide](https://github.com/csrc-sdsu/mole/blob/main/doc/sphinx/README.md).
+- **MOLE.jl Documentation**: Access the [MOLE.jl Documentation](https://www.mole-ose.org/MOLE.jl-docs/dev/) for the description of the MOLE Julia language implementation.
 
 > **Important Note:** Performing non-unary operations involving operands constructed over different grids may lead to unexpected results. While MOLE allows such operations without throwing errors, users must exercise caution when manipulating operators across different grids.
 

--- a/doc/sphinx/source/api/julia/index.md
+++ b/doc/sphinx/source/api/julia/index.md
@@ -1,0 +1,172 @@
+# Julia
+
+This section documents the Julia implementation of the MOLE toolkit, MOLE.jl.
+
+The API documentation is generated automatically from the docstrings in the Julia source files located in `mole/julia/MOLE.jl/src`.
+
+The published MOLE.jl documentation can be found on the [MOLE.jl Documentation website](https://www.mole-ose.org/MOLE.jl-docs/dev/).
+
+```{eval-rst}
+.. only:: html
+
+    The following diagram shows the key modules and functions in the MOLE.jl API and their relationships:
+
+    .. graphviz::
+
+        digraph mole_jl_api_structure {
+            bgcolor="transparent";
+            rankdir=TB;  // Top to Bottom layout
+            compound=true;
+            node [shape=box, style=filled, fontname="Arial", fontsize=10, margin="0.3,0.1"];
+            edge [fontname="Arial", fontsize=9];
+
+            // Color definitions
+            node [fillcolor="#E8F4F9"];  // Light blue for base nodes
+
+            // Core package
+            subgraph cluster_base {
+                label="Core Package";
+                style=filled;
+                color="#F5F5F5";
+
+                MOLE [label="MOLE.jl\n(Package)"];
+            }
+
+            // Core modules
+            subgraph cluster_modules {
+                label="Core Modules";
+                style=filled;
+                color="#F5F5F5";
+                node [fillcolor="#E8F4F9"];
+
+                Operators [label="Operators"];
+                BCs [label="BCs"];
+            }
+
+            // Operators
+            subgraph cluster_operators {
+                label="Core Operators";
+                style=filled;
+                color="#F5F5F5";
+                node [fillcolor="#D5E8D4"];  // Light green for operators
+
+                Interpol [label="interpol\n(Interpolation)"];
+                Gradient [label="grad\n(Gradient)"];
+                Divergence [label="div\n(Divergence)"];
+                Laplacian [label="lap\n(Laplacian)"];
+            }
+
+            // Boundary Conditions
+            subgraph cluster_bc {
+                label="Boundary Conditions";
+                style=filled;
+                color="#F5F5F5";
+                node [fillcolor="#FFE6CC"];  // Light orange for boundary conditions
+
+                RobinBC [label="robinBC\n(Robin/Neumann/Dirichlet)"];
+                ScalarBC1D [label="ScalarBC1D"];
+                ScalarBC2D [label="ScalarBC2D"];
+                AddScalarBC [label="addScalarBC!\n(Apply Scalar BCs)"];
+            }
+
+            // Grid Variants
+            subgraph cluster_grids {
+                label="Grid and Dimension Variants";
+                style=filled;
+                color="#F5F5F5";
+                node [fillcolor="#DAE8FC"];  // Light blue for utilities
+
+                OneD [label="1D Operators"];
+                TwoD [label="2D Operators"];
+                Uniform [label="Uniform Grids"];
+                NonUniform [label="Non-uniform Grids"];
+            }
+
+            // Module relationships
+            edge [color="#0000AA", penwidth=1.5];
+            MOLE -> {Operators BCs};
+
+            // API ownership relationships
+            edge [color="#0000AA", penwidth=1.5];
+            Operators -> {Interpol Gradient Divergence Laplacian};
+            BCs -> {RobinBC ScalarBC1D ScalarBC2D AddScalarBC};
+
+            // Usage relationships
+            edge [style=dashed, dir=forward, color="#006600", penwidth=1.0];
+            Gradient -> Laplacian;
+            Divergence -> Laplacian;
+
+            // Grid and dimension relationships
+            edge [style=dotted, dir=forward, color="#990000", penwidth=1.0];
+            OneD -> {Interpol Gradient Divergence Laplacian RobinBC ScalarBC1D AddScalarBC};
+            TwoD -> {Gradient Divergence Laplacian RobinBC ScalarBC2D AddScalarBC};
+            Uniform -> {Interpol Gradient Divergence Laplacian};
+            NonUniform -> {Gradient Divergence};
+
+            // Boundary condition relationships
+            edge [style=dashed, constraint=false, color="#AA6600", penwidth=1.0];
+            RobinBC -> {Gradient Divergence Laplacian};
+            ScalarBC1D -> AddScalarBC;
+            ScalarBC2D -> AddScalarBC;
+            AddScalarBC -> {Gradient Divergence Laplacian};
+
+            // Add a legend
+            subgraph cluster_legend {
+                label="Legend";
+                style=filled;
+                color="#F5F5F5";
+                fontsize=10;
+
+                node [shape=none, style=none, label=""];
+                edge [style=none];
+
+                leg_title [label="Relationship Types:", shape=none, fontsize=9];
+                leg_module [label="Module/API Ownership", shape=none, fontsize=9];
+                leg_usage [label="Operator Usage", shape=none, fontsize=9];
+                leg_grid [label="Grid/Dimension Support", shape=none, fontsize=9];
+                leg_boundary [label="Boundary Modification", shape=none, fontsize=9];
+
+                leg_title -> leg_module [style=solid, color="#0000AA", penwidth=1.5];
+                leg_title -> leg_usage [style=dashed, color="#006600", penwidth=1.0];
+                leg_title -> leg_grid [style=dotted, color="#990000", penwidth=1.0];
+                leg_title -> leg_boundary [style=dashed, color="#AA6600", penwidth=1.0];
+            }
+        }
+
+.. only:: latex
+
+    The MOLE.jl API consists of several key components:
+
+    Core Package:
+        * **MOLE.jl**: Julia implementation of Mimetic Operators Library Enhanced.
+
+    Core Modules:
+        * **MOLE.Operators**: Provides mimetic discrete operators.
+        * **MOLE.BCs**: Provides boundary-condition utilities and scalar boundary-condition support.
+
+    Core Operators:
+        * **interpol**: Interpolation operator for grid transformations.
+        * **grad**: Gradient operator with support for one- and two-dimensional grids.
+        * **div**: Divergence operator with support for one- and two-dimensional grids.
+        * **lap**: Laplacian operator related to gradient and divergence operators.
+
+    Boundary Conditions:
+        * **robinBC**: Constructs Robin, Neumann, and Dirichlet boundary-condition contributions.
+        * **ScalarBC1D**: Scalar boundary-condition data for one-dimensional problems.
+        * **ScalarBC2D**: Scalar boundary-condition data for two-dimensional problems.
+        * **addScalarBC!**: Applies scalar boundary conditions to operators or systems.
+
+    Grid and Dimension Variants:
+        * **1D Operators**: One-dimensional versions of interpolation, gradient, divergence, Laplacian, and boundary-condition routines.
+        * **2D Operators**: Two-dimensional versions of gradient, divergence, Laplacian, and boundary-condition routines.
+        * **Uniform Grids**: Operators defined using regular grid spacing.
+        * **Non-uniform Grids**: Operators defined using coordinate ticks or non-uniform grid spacing.
+
+    Key Features:
+        * MOLE.jl exposes operators through Julia modules rather than C++ classes.
+        * Core operators are grouped under **MOLE.Operators**.
+        * Boundary-condition tools are grouped under **MOLE.BCs**.
+        * Laplacian functionality is closely related to Gradient and Divergence.
+        * Boundary-condition utilities can modify operator behavior or system matrices.
+        * Several operators support both uniform and non-uniform grids.
+```

--- a/doc/sphinx/source/index.md
+++ b/doc/sphinx/source/index.md
@@ -25,6 +25,7 @@ Documentation Guide <intros/doc_readme_wrapper>
 
 api/cpp/index
 api/matlab_octave/index-beta
+api/julia/index
 ```
 
 ```{toctree}

--- a/julia/MOLE.jl/README.md
+++ b/julia/MOLE.jl/README.md
@@ -91,6 +91,8 @@ The examples are organized by PDE type and dimension in the base MOLE documentat
 
 Currently, not all of them are available in the MOLE Julia package. They will be added in the near future.
 
+- **MOLE.jl Documentation:** The [MOLE.jl documentation](https://www.mole-ose.org/MOLE.jl-docs/dev/) is publicly available.
+
 ## Formatter
 
 To test the JuliaFormatter locally, please make sure to have a working julia installation and add the `JuliaFormatter` package to your either global or local environment. At a global, system level, this would be:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [x] Documentation

## Description
This PR adds a link to the MOLE.jl deployed documentation both on the top-level README and the julia/MOLE.jl/README files.


## Related Issues & Documents

- [x] I have created an Issue that is paired with this PR
- Closes #401 



## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [x] No, and this is why: N/A
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [x] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md
