### PR TITLE
Grid error handling and error code table (MOLE 2.0)

### DIFF
--- a/src/matlab_octave/addScalarBC.m
+++ b/src/matlab_octave/addScalarBC.m
@@ -1,4 +1,4 @@
-function [A, b] = addScalarBC(A, b, k, grid, v)
+function [A, b, err] = addScalarBC(A, b, k, grid, v)
 % PURPOSE
 % Apply scalar boundary conditions to a linear system for any grid dimension.
 %
@@ -34,5 +34,9 @@ function [A, b] = addScalarBC(A, b, k, grid, v)
 
     ensureMatlabOctaveSubdirs();
     grid = validateGrid(grid);
+    err = grid.error;
+    if err.hasError
+        return;
+    end
     [A, b] = addScalarBC_impl(A, b, k, grid, v);
 end

--- a/src/matlab_octave/api/ERROR_CODES.md
+++ b/src/matlab_octave/api/ERROR_CODES.md
@@ -1,0 +1,38 @@
+# MOLE 2.0 API Error Codes
+
+This document provides a comprehensive table of standardized error codes returned by the `makeGrid` and `validateGrid` API functions.
+
+Instead of throwing hard MATLAB exceptions, these functions safely populate and return a standardized `grid.error` structure. The `code` field categorizes the failure, while the `id` field provides a one-to-one traceable identifier for the specific missing field or invalid state.
+
+## Error Code Table (100 - 199)
+
+| Code | Error Category | Description | Common Traceable IDs |
+| :--- | :--- | :--- | :--- |
+| **100** | **Invalid Input Structure** | The function was called with an invalid type (e.g. a number instead of a struct) or bad Name-Value pairs. | `validateGrid:InvalidInput`<br>`makeGrid:InvalidInput`<br>`makeGrid:InvalidFieldName` |
+| **101** | **Missing Essential Dimensions** | The grid struct lacks necessary discretization counts (`m`, `n`, `o`) for its stated dimensionality. | `validateGrid:MissingM`<br>`validateGrid:MissingN`<br>`validateGrid:MissingO`<br>`validateGrid:MissingField1D` |
+| **102** | **Invalid Grid Dimensionality** | The `dim` field is explicitly invalid (e.g., >3) or doesn't match the specific dimensionality of the operator requesting it. | `validateGrid:InvalidDim`<br>`validateGrid:InvalidDim1D`<br>`validateGrid:InvalidDim2D` |
+| **103** | **Missing Uniform Spacing** | A uniform grid is missing required spacing parameters (`dx`, `dy`, `dz`). | `validateGrid:MissingDx`<br>`validateGrid:MissingDy`<br>`validateGrid:MissingDz`<br>`validateGrid:MissingUniform1D` |
+| **104** | **Invalid Boundary Specifications** | The `grid.bc` structure contains incompatible configurations (e.g., `dc` provided without `nc` or vice versa). | `validateGrid:InvalidBC1D`<br>`validateGrid:InvalidBC2D`<br>`validateGrid:InvalidBC3D` |
+| **105** | **Incorrect Boundary Vector Type/Size** | A boundary coefficient (`dc` or `nc`) is non-numeric, or its length does not match the expected count (2 for 1D, 4 for 2D, 6 for 3D) after scalar expansion. | `validateGrid:InvalidBC1D`<br>`validateGrid:InvalidBC2D`<br>`validateGrid:InvalidBC3D` |
+| **106** | **Missing Curvilinear Coordinates** | A curvilinear grid was specified, but it lacks the required physical node coordinates (`grid.nodes.X`, `grid.nodes.Y`). | `validateGrid:CurvilinearMissingNodes` |
+| **107** | **Curvilinear Size Mismatch** | The provided physical node coordinates do not match the expected `(m+1) x (n+1)` dimension requirements. | `validateGrid:SizeMismatch` |
+| **108** | **Periodic Boundary Conflict** | A user marked an axis as periodic (`bc.isPeriodic = true`), but supplied non-zero Dirichlet or Neumann coefficients for it. | `validateGrid:PeriodicBCConflict` |
+
+---
+
+### Usage Note
+
+When writing automated tests or catching failures in caller code, you can use the `code` to handle broad categories of errors:
+```matlab
+g = validateGrid(myStruct);
+if g.error.hasError && g.error.code == 101
+    % Handle any missing grid dimension
+end
+```
+
+For strict, exact one-to-one traceability, use the string `id`:
+```matlab
+if g.error.hasError && strcmp(g.error.id, 'validateGrid:MissingDx')
+    % Specifically handle missing dx
+end
+```

--- a/src/matlab_octave/api/addGridError.m
+++ b/src/matlab_octave/api/addGridError.m
@@ -1,0 +1,28 @@
+function grid = addGridError(grid, code, id, field, message)
+% ADDGRIDERROR Attach a standardized error structure to a grid-like object.
+%   If input is not a struct, create a struct so callers can safely return
+%   grid.error instead of throwing.
+
+    if nargin < 5, message = ''; end
+    if nargin < 4, field = ''; end
+    if nargin < 3, id = 'grid:Error'; end
+    if nargin < 2, code = 100; end
+
+    if ~isstruct(grid)
+        grid = struct();
+    end
+
+    if ~isfield(grid, 'error') || ~isstruct(grid.error)
+        grid.error = struct('hasError', false, ...
+                            'code', 0, ...
+                            'id', '', ...
+                            'field', '', ...
+                            'message', '');
+    end
+
+    grid.error.hasError = true;
+    grid.error.code = code;
+    grid.error.id = char(id);
+    grid.error.field = char(field);
+    grid.error.message = char(message);
+end

--- a/src/matlab_octave/api/makeGrid_impl.m
+++ b/src/matlab_octave/api/makeGrid_impl.m
@@ -4,15 +4,20 @@ function grid = makeGrid_impl(varargin)
     if nargin == 1 && isstruct(varargin{1})
         grid = varargin{1};
     else
-        assert(mod(nargin, 2) == 0, ...
-               'makeGrid expects a struct or name-value pairs');
+        if mod(nargin, 2) ~= 0
+            grid = struct();
+            grid = addGridError(grid, 100, 'makeGrid:InvalidInput', '', 'makeGrid expects a struct or name-value pairs');
+            return;
+        end
 
         grid = struct();
         for i = 1:2:nargin
             name = varargin{i};
             value = varargin{i + 1};
-            assert(ischar(name) || isstring(name), ...
-                   'Grid field names must be character vectors or strings');
+            if ~(ischar(name) || isstring(name))
+                grid = addGridError(grid, 100, 'makeGrid:InvalidFieldName', '', 'Grid field names must be character vectors or strings');
+                return;
+            end
             grid.(char(name)) = value;
         end
     end

--- a/src/matlab_octave/api/validateGrid_impl.m
+++ b/src/matlab_octave/api/validateGrid_impl.m
@@ -9,9 +9,8 @@ function grid = validateGrid_impl(grid, allowPartial)
 % grid.nodes, grid.faces, and grid.centers with meshgrid-style arrays.
 % For curvilinear grids, grid.nodes.X/Y must be supplied by the caller;
 % faces and centers are derived by interpolation.
-% Throws validateGrid:SizeMismatch if pre-populated coordinate arrays
-% disagree with m/n/o, and validateGrid:CurvilinearMissingNodes if a
-% curvilinear grid lacks node coordinates.
+% On validation failure, returns immediately with grid.error populated.
+% Grid-related errors use codes 100-199.
 %
 % Parameters:
 %   grid         : Input struct (partial or complete)
@@ -32,7 +31,15 @@ function grid = validateGrid_impl(grid, allowPartial)
         allowPartial = false;
     end
 
-    assert(isstruct(grid), 'grid must be a struct');
+    if ~isstruct(grid)
+        grid = struct();
+        grid = addGridError(grid, 100, 'validateGrid:InvalidInput', '', 'grid must be a struct');
+        return;
+    end
+
+    if ~isfield(grid, 'error') || ~isstruct(grid.error)
+        grid.error = struct('hasError', false, 'code', 0, 'id', '', 'field', '', 'message', '');
+    end
 
     if ~isfield(grid, 'bc') || ~isstruct(grid.bc)
         grid.bc = struct();
@@ -67,23 +74,31 @@ function grid = validateGrid_impl(grid, allowPartial)
 
     switch grid.dim
     case 1
-        localRequire(grid, {'m'}, allowPartial, 'validateGrid:MissingField1D');
+        grid = localRequire(grid, {'m'}, allowPartial, 'validateGrid:MissingField1D');
+        if grid.error.hasError, return; end
         grid = localNormalizeIfUniform1D(grid, allowPartial);
+        if grid.error.hasError, return; end
     case 2
-        localRequire(grid, {'m', 'n'}, allowPartial, 'validateGrid:MissingField2D');
+        grid = localRequire(grid, {'m', 'n'}, allowPartial, 'validateGrid:MissingField2D');
+        if grid.error.hasError, return; end
         grid = localNormalizeIfUniform2D(grid, allowPartial);
+        if grid.error.hasError, return; end
     case 3
-        localRequire(grid, {'m', 'n', 'o'}, allowPartial, 'validateGrid:MissingField3D');
+        grid = localRequire(grid, {'m', 'n', 'o'}, allowPartial, 'validateGrid:MissingField3D');
+        if grid.error.hasError, return; end
         grid = localNormalizeIfUniform3D(grid, allowPartial);
+        if grid.error.hasError, return; end
     otherwise
-        error('validateGrid:InvalidDim', 'grid.dim must be 1, 2, or 3');
+        grid = addGridError(grid, 102, 'validateGrid:InvalidDim', 'dim', 'grid.dim must be 1, 2, or 3');
+        return;
     end
 end
 
-function localRequire(grid, names, allowPartial, errId)
+function grid = localRequire(grid, names, allowPartial, errId)
     for i = 1:numel(names)
         if ~isfield(grid, names{i}) && ~allowPartial
-            error(errId, ['Missing required field grid.' names{i}]);
+            grid = addGridError(grid, 101, errId, names{i}, ['Missing required field grid.' names{i}]);
+            return;
         end
     end
 end
@@ -93,8 +108,8 @@ function grid = localNormalizeIfUniform1D(grid, allowPartial)
     if hasUniform
         grid = localNormalizeGrid1D(grid);
     elseif ~allowPartial && strcmpi(grid.type, 'uniform')
-        error('validateGrid:MissingUniform1D', ...
-              'Uniform 1-D grid requires grid.m and grid.dx');
+        grid = addGridError(grid, 103, 'validateGrid:MissingUniform1D', '', 'Uniform 1-D grid requires grid.m and grid.dx');
+        return;
     end
 end
 
@@ -112,8 +127,8 @@ function grid = localNormalizeIfUniform2D(grid, allowPartial)
     if hasUniform
         grid = localNormalizeGrid2D(grid);
     elseif ~allowPartial && strcmpi(grid.type, 'uniform')
-        error('validateGrid:MissingUniform2D', ...
-              'Uniform 2-D grid requires grid.m, grid.n, grid.dx, and grid.dy');
+        grid = addGridError(grid, 103, 'validateGrid:MissingUniform2D', '', 'Uniform 2-D grid requires grid.m, grid.n, grid.dx, and grid.dy');
+        return;
     end
 end
 
@@ -123,20 +138,23 @@ function grid = localNormalizeIfUniform3D(grid, allowPartial)
     if hasUniform
         grid = localNormalizeGrid3D(grid);
     elseif ~allowPartial && strcmpi(grid.type, 'uniform')
-        error('validateGrid:MissingUniform3D', ...
-              'Uniform 3-D grid requires grid.m, grid.n, grid.o, grid.dx, grid.dy, and grid.dz');
+        grid = addGridError(grid, 103, 'validateGrid:MissingUniform3D', '', 'Uniform 3-D grid requires grid.m, grid.n, grid.o, grid.dx, grid.dy, and grid.dz');
+        return;
     end
 end
 
 function grid = localNormalizeGrid1D(grid)
     if isfield(grid, 'dim')
-        assert(grid.dim == 1, 'grid.dim must be 1 for 1-D operators');
+        if grid.dim ~= 1
+            grid = addGridError(grid, 102, 'validateGrid:InvalidDim1D', 'dim', 'grid.dim must be 1 for 1-D operators');
+            return;
+        end
     else
         grid.dim = 1;
     end
 
-    assert(isfield(grid, 'm'), 'grid.m is required');
-    assert(isfield(grid, 'dx'), 'grid.dx is required for uniform 1-D operators');
+    if ~isfield(grid, 'm'), grid = addGridError(grid, 101, 'validateGrid:MissingM', 'm', 'grid.m is required'); return; end
+    if ~isfield(grid, 'dx'), grid = addGridError(grid, 103, 'validateGrid:MissingDx', 'dx', 'grid.dx is required for uniform 1-D operators'); return; end
 
     grid.m = double(grid.m);
     grid.dx = double(grid.dx);
@@ -154,12 +172,13 @@ function grid = localNormalizeGrid1D(grid)
         bc.nc = grid.nc;
     end
 
-    [bc.dc, bc.nc, bc.hasData] = localNormalizeBoundaryCoefficients(bc, 2, 'validateGrid:InvalidBC1D');
-    if bc.hasData
-        bc.isPeriodic = isempty(find(bc.dc .* bc.dc + bc.nc .* bc.nc, 1));
-    else
-        bc.isPeriodic = false;
+    [bc.dc, bc.nc, bc.hasData, errGrid] = localNormalizeBoundaryCoefficients(grid, bc, 2, 'validateGrid:InvalidBC1D');
+    if errGrid.error.hasError
+        grid = errGrid;
+        return;
     end
+    [bc.isPeriodic, grid] = localNormalizeIsPeriodic(grid, bc, bc.hasData, 1, 'validateGrid:InvalidBC1D');
+    if grid.error.hasError, return; end
 
     grid.bc = bc;
     if grid.bc.isPeriodic
@@ -173,15 +192,18 @@ end
 
 function grid = localNormalizeGrid2D(grid)
     if isfield(grid, 'dim')
-        assert(grid.dim == 2, 'grid.dim must be 2 for 2-D operators');
+        if grid.dim ~= 2
+            grid = addGridError(grid, 102, 'validateGrid:InvalidDim2D', 'dim', 'grid.dim must be 2 for 2-D operators');
+            return;
+        end
     else
         grid.dim = 2;
     end
 
-    assert(isfield(grid, 'm'), 'grid.m is required');
-    assert(isfield(grid, 'n'), 'grid.n is required');
-    assert(isfield(grid, 'dx'), 'grid.dx is required for uniform 2-D operators');
-    assert(isfield(grid, 'dy'), 'grid.dy is required for uniform 2-D operators');
+    if ~isfield(grid, 'm'), grid = addGridError(grid, 101, 'validateGrid:MissingM', 'm', 'grid.m is required'); return; end
+    if ~isfield(grid, 'n'), grid = addGridError(grid, 101, 'validateGrid:MissingN', 'n', 'grid.n is required'); return; end
+    if ~isfield(grid, 'dx'), grid = addGridError(grid, 103, 'validateGrid:MissingDx', 'dx', 'grid.dx is required for uniform 2-D operators'); return; end
+    if ~isfield(grid, 'dy'), grid = addGridError(grid, 103, 'validateGrid:MissingDy', 'dy', 'grid.dy is required for uniform 2-D operators'); return; end
 
     grid.m = double(grid.m);
     grid.n = double(grid.n);
@@ -201,13 +223,13 @@ function grid = localNormalizeGrid2D(grid)
         bc.nc = grid.nc;
     end
 
-    [bc.dc, bc.nc, bc.hasData] = localNormalizeBoundaryCoefficients(bc, 4, 'validateGrid:InvalidBC2D');
-    if bc.hasData
-        bc.isPeriodic = [isempty(find(bc.dc(1:2).^2 + bc.nc(1:2).^2, 1)); ...
-                         isempty(find(bc.dc(3:4).^2 + bc.nc(3:4).^2, 1))];
-    else
-        bc.isPeriodic = [false; false];
+    [bc.dc, bc.nc, bc.hasData, errGrid] = localNormalizeBoundaryCoefficients(grid, bc, 4, 'validateGrid:InvalidBC2D');
+    if errGrid.error.hasError
+        grid = errGrid;
+        return;
     end
+    [bc.isPeriodic, grid] = localNormalizeIsPeriodic(grid, bc, bc.hasData, 2, 'validateGrid:InvalidBC2D');
+    if grid.error.hasError, return; end
 
     grid.bc = bc;
     if any(grid.bc.isPeriodic)
@@ -221,17 +243,20 @@ end
 
 function grid = localNormalizeGrid3D(grid)
     if isfield(grid, 'dim')
-        assert(grid.dim == 3, 'grid.dim must be 3 for 3-D operators');
+        if grid.dim ~= 3
+            grid = addGridError(grid, 102, 'validateGrid:InvalidDim3D', 'dim', 'grid.dim must be 3 for 3-D operators');
+            return;
+        end
     else
         grid.dim = 3;
     end
 
-    assert(isfield(grid, 'm'), 'grid.m is required');
-    assert(isfield(grid, 'n'), 'grid.n is required');
-    assert(isfield(grid, 'o'), 'grid.o is required');
-    assert(isfield(grid, 'dx'), 'grid.dx is required for uniform 3-D operators');
-    assert(isfield(grid, 'dy'), 'grid.dy is required for uniform 3-D operators');
-    assert(isfield(grid, 'dz'), 'grid.dz is required for uniform 3-D operators');
+    if ~isfield(grid, 'm'), grid = addGridError(grid, 101, 'validateGrid:MissingM', 'm', 'grid.m is required'); return; end
+    if ~isfield(grid, 'n'), grid = addGridError(grid, 101, 'validateGrid:MissingN', 'n', 'grid.n is required'); return; end
+    if ~isfield(grid, 'o'), grid = addGridError(grid, 101, 'validateGrid:MissingO', 'o', 'grid.o is required'); return; end
+    if ~isfield(grid, 'dx'), grid = addGridError(grid, 103, 'validateGrid:MissingDx', 'dx', 'grid.dx is required for uniform 3-D operators'); return; end
+    if ~isfield(grid, 'dy'), grid = addGridError(grid, 103, 'validateGrid:MissingDy', 'dy', 'grid.dy is required for uniform 3-D operators'); return; end
+    if ~isfield(grid, 'dz'), grid = addGridError(grid, 103, 'validateGrid:MissingDz', 'dz', 'grid.dz is required for uniform 3-D operators'); return; end
 
     grid.m = double(grid.m);
     grid.n = double(grid.n);
@@ -253,14 +278,13 @@ function grid = localNormalizeGrid3D(grid)
         bc.nc = grid.nc;
     end
 
-    [bc.dc, bc.nc, bc.hasData] = localNormalizeBoundaryCoefficients(bc, 6, 'validateGrid:InvalidBC3D');
-    if bc.hasData
-        bc.isPeriodic = [isempty(find(bc.dc(1:2).^2 + bc.nc(1:2).^2, 1)); ...
-                         isempty(find(bc.dc(3:4).^2 + bc.nc(3:4).^2, 1)); ...
-                         isempty(find(bc.dc(5:6).^2 + bc.nc(5:6).^2, 1))];
-    else
-        bc.isPeriodic = [false; false; false];
+    [bc.dc, bc.nc, bc.hasData, errGrid] = localNormalizeBoundaryCoefficients(grid, bc, 6, 'validateGrid:InvalidBC3D');
+    if errGrid.error.hasError
+        grid = errGrid;
+        return;
     end
+    [bc.isPeriodic, grid] = localNormalizeIsPeriodic(grid, bc, bc.hasData, 3, 'validateGrid:InvalidBC3D');
+    if grid.error.hasError, return; end
 
     grid.bc = bc;
     if any(grid.bc.isPeriodic)
@@ -272,7 +296,7 @@ function grid = localNormalizeGrid3D(grid)
     grid = localGenerateCoordinates3D(grid);
 end
 
-function [dc, nc, hasData] = localNormalizeBoundaryCoefficients(bc, expectedCount, errId)
+function [dc, nc, hasData, grid] = localNormalizeBoundaryCoefficients(grid, bc, expectedCount, errId)
     hasDC = isfield(bc, 'dc');
     hasNC = isfield(bc, 'nc');
 
@@ -284,7 +308,8 @@ function [dc, nc, hasData] = localNormalizeBoundaryCoefficients(bc, expectedCoun
     end
 
     if hasDC ~= hasNC
-        error(errId, 'grid.bc.dc and grid.bc.nc must be provided together');
+        grid = addGridError(grid, 104, errId, 'bc', 'grid.bc.dc and grid.bc.nc must be provided together');
+        dc=[]; nc=[]; hasData=false; return;
     end
 
     if isempty(bc.dc) && isempty(bc.nc)
@@ -295,23 +320,33 @@ function [dc, nc, hasData] = localNormalizeBoundaryCoefficients(bc, expectedCoun
     end
 
     if isempty(bc.dc) || isempty(bc.nc)
-        error(errId, 'grid.bc.dc and grid.bc.nc must both be empty or both be non-empty');
+        grid = addGridError(grid, 104, errId, 'bc', 'grid.bc.dc and grid.bc.nc must both be empty or both be non-empty');
+        dc=[]; nc=[]; hasData=false; return;
     end
 
-    dc = localNormalizeBoundaryVector(bc.dc, expectedCount, 'grid.bc.dc', errId);
-    nc = localNormalizeBoundaryVector(bc.nc, expectedCount, 'grid.bc.nc', errId);
+    [dc, grid] = localNormalizeBoundaryVector(grid, bc.dc, expectedCount, 'grid.bc.dc', errId);
+    if grid.error.hasError, nc=[]; hasData=false; return; end
+    [nc, grid] = localNormalizeBoundaryVector(grid, bc.nc, expectedCount, 'grid.bc.nc', errId);
+    if grid.error.hasError, dc=[]; hasData=false; return; end
     hasData = true;
 end
 
-function values = localNormalizeBoundaryVector(values, expectedCount, fieldName, errId)
-    assert(isnumeric(values), [fieldName ' must be numeric']);
-    assert(isvector(values), [fieldName ' must be a scalar or vector']);
+function [values, grid] = localNormalizeBoundaryVector(grid, values, expectedCount, fieldName, errId)
+    if ~isnumeric(values)
+        grid = addGridError(grid, 105, errId, fieldName, [fieldName ' must be numeric']);
+        values=[]; return;
+    end
+    if ~isvector(values)
+        grid = addGridError(grid, 105, errId, fieldName, [fieldName ' must be a scalar or vector']);
+        values=[]; return;
+    end
 
     values = double(values(:));
     if numel(values) == 1
         values = repmat(values, expectedCount, 1);
     elseif numel(values) ~= expectedCount
-        error(errId, '%s must be a scalar or a %dx1 vector', fieldName, expectedCount);
+        grid = addGridError(grid, 105, errId, fieldName, sprintf('%s must be a scalar or a %dx1 vector', fieldName, expectedCount));
+        values=[]; return;
     end
 end
 
@@ -368,27 +403,32 @@ end
 
 function grid = localNormalizeCurvilinear2D(grid)
     if isfield(grid, 'dim')
-        assert(grid.dim == 2, 'grid.dim must be 2 for 2-D operators');
+        if grid.dim ~= 2
+            grid = addGridError(grid, 102, 'validateGrid:InvalidDim2D', 'dim', 'grid.dim must be 2 for 2-D operators');
+            return;
+        end
     else
         grid.dim = 2;
     end
     grid.m = double(grid.m);
     grid.n = double(grid.n);
     grid = localValidateCurvilinearNodes2D(grid);
+    if grid.error.hasError, return; end
     grid = localDeriveCurvilinearCoordinates2D(grid);
 end
 
 function grid = localValidateCurvilinearNodes2D(grid)
     m = grid.m; n = grid.n;
     if ~isfield(grid, 'nodes') || ~isfield(grid.nodes, 'X') || ~isfield(grid.nodes, 'Y')
-        error('validateGrid:CurvilinearMissingNodes', ...
-            'Curvilinear grid requires grid.nodes.X and grid.nodes.Y to be set before calling validateGrid.');
+        grid = addGridError(grid, 106, 'validateGrid:CurvilinearMissingNodes', 'nodes', 'Curvilinear grid requires grid.nodes.X and grid.nodes.Y to be set before calling validateGrid.');
+        return;
     end
     expected = [m+1, n+1];
     if ~isequal(size(grid.nodes.X), expected) || ~isequal(size(grid.nodes.Y), expected)
-        error('validateGrid:SizeMismatch', ...
-            'Curvilinear grid.nodes.X/Y must be (%d x %d); got (%s) and (%s).', ...
-            m+1, n+1, mat2str(size(grid.nodes.X)), mat2str(size(grid.nodes.Y)));
+        grid = addGridError(grid, 107, 'validateGrid:SizeMismatch', 'nodes', ...
+            sprintf('Curvilinear grid.nodes.X/Y must be (%d x %d); got %s and %s.', ...
+            m+1, n+1, mat2str(size(grid.nodes.X)), mat2str(size(grid.nodes.Y))));
+        return;
     end
 end
 
@@ -406,4 +446,40 @@ function grid = localDeriveCurvilinearCoordinates2D(grid)
                               NX(1:end-1, 2:end)   + NX(2:end, 2:end));
     grid.centers.Y = 0.25 * (NY(1:end-1, 1:end-1) + NY(2:end, 1:end-1) + ...
                               NY(1:end-1, 2:end)   + NY(2:end, 2:end));
+end
+
+function [isPeriodic, grid] = localNormalizeIsPeriodic(grid, bc, hasData, numAxes, errId)
+    if isfield(bc, 'isPeriodic')
+        if ~islogical(bc.isPeriodic) && ~isnumeric(bc.isPeriodic)
+            grid = addGridError(grid, 105, errId, 'bc.isPeriodic', 'isPeriodic must be logical');
+            isPeriodic = []; return;
+        end
+        isPeriodic = logical(bc.isPeriodic(:));
+        if numel(isPeriodic) == 1
+            isPeriodic = repmat(isPeriodic, numAxes, 1);
+        elseif numel(isPeriodic) ~= numAxes
+            grid = addGridError(grid, 105, errId, 'bc.isPeriodic', sprintf('isPeriodic must be a scalar or %dx1 logical vector', numAxes));
+            isPeriodic = []; return;
+        end
+        
+        if hasData
+            for a = 1:numAxes
+                idx1 = 2*a - 1;
+                idx2 = 2*a;
+                if isPeriodic(a) && ~isempty(find(bc.dc(idx1:idx2).^2 + bc.nc(idx1:idx2).^2, 1))
+                    grid = addGridError(grid, 108, 'validateGrid:PeriodicBCConflict', 'bc', 'Periodic axis cannot carry non-periodic BC coefficients');
+                    return;
+                end
+            end
+        end
+    else
+        isPeriodic = false(numAxes, 1);
+        if hasData
+            for a = 1:numAxes
+                idx1 = 2*a - 1;
+                idx2 = 2*a;
+                isPeriodic(a) = isempty(find(bc.dc(idx1:idx2).^2 + bc.nc(idx1:idx2).^2, 1));
+            end
+        end
+    end
 end

--- a/src/matlab_octave/curl.m
+++ b/src/matlab_octave/curl.m
@@ -1,4 +1,4 @@
-function C = curl(grid, k)
+function [C, err] = curl(grid, k)
 % PURPOSE
 % Returns the mimetic 2-D curl operator for a uniform grid.
 %
@@ -28,5 +28,5 @@ function C = curl(grid, k)
     end
 
     ensureMatlabOctaveSubdirs();
-    C = curlOp_impl(grid, k);
+    [C, err] = curlOp_impl(grid, k);
 end

--- a/src/matlab_octave/div.m
+++ b/src/matlab_octave/div.m
@@ -1,4 +1,4 @@
-function D = div(varargin)
+function [D, err] = div(varargin)
 % PURPOSE
 % Mimetic divergence operator — 1-D, 2-D, and 3-D, uniform and curvilinear.
 %
@@ -29,5 +29,5 @@ function D = div(varargin)
     grid = varargin{1};
     k    = varargin{2};
     ensureMatlabOctaveSubdirs();
-    D = divOp_impl(grid, k);
+    [D, err] = divOp_impl(grid, k);
 end

--- a/src/matlab_octave/grad.m
+++ b/src/matlab_octave/grad.m
@@ -1,4 +1,4 @@
-function G = grad(varargin)
+function [G, err] = grad(varargin)
 % PURPOSE
 % Mimetic gradient operator — 1-D, 2-D, and 3-D, uniform and curvilinear.
 %
@@ -29,5 +29,5 @@ function G = grad(varargin)
     grid = varargin{1};
     k    = varargin{2};
     ensureMatlabOctaveSubdirs();
-    G = gradOp_impl(grid, k);
+    [G, err] = gradOp_impl(grid, k);
 end

--- a/src/matlab_octave/interpol.m
+++ b/src/matlab_octave/interpol.m
@@ -1,4 +1,4 @@
-function I = interpol(grid, direction)
+function [I, err] = interpol(grid, direction)
 % PURPOSE
 % Returns an interpolation operator for the specified transfer direction.
 %
@@ -32,5 +32,10 @@ function I = interpol(grid, direction)
 
     ensureMatlabOctaveSubdirs();
     grid = validateGrid(grid);
+    err = grid.error;
+    if err.hasError
+        I = [];
+        return;
+    end
     I = interpol_impl(grid, direction);
 end

--- a/src/matlab_octave/nodal.m
+++ b/src/matlab_octave/nodal.m
@@ -1,4 +1,4 @@
-function N = nodal(varargin)
+function [N, err] = nodal(varargin)
 % PURPOSE
 % Mimetic nodal derivative operator — 1-D, 2-D, and 3-D.
 %
@@ -28,7 +28,7 @@ function N = nodal(varargin)
         grid = varargin{1};
         k    = varargin{2};
         ensureMatlabOctaveSubdirs();
-        N = nodalOp_impl(grid, k);
+        [N, err] = nodalOp_impl(grid, k);
         return;
     end
 
@@ -41,7 +41,7 @@ function N = nodal(varargin)
         dx = varargin{3};
         grid = makeGrid('m', m_nodes - 1, 'dx', dx);
         ensureMatlabOctaveSubdirs();
-        N = nodalOp_impl(grid, k);
+        [N, err] = nodalOp_impl(grid, k);
         return;
     end
 

--- a/src/matlab_octave/operators/curl/curlOp_impl.m
+++ b/src/matlab_octave/operators/curl/curlOp_impl.m
@@ -1,4 +1,4 @@
-function C = curlOp_impl(grid, k)
+function [C, err] = curlOp_impl(grid, k)
 % PURPOSE
 % Grid-first mimetic 2-D curl operator.
 %
@@ -24,6 +24,11 @@ function C = curlOp_impl(grid, k)
 % ----------------------------------------------------------------------------
 
     grid = validateGrid(grid);
+    err = grid.error;
+    if err.hasError
+        C = [];
+        return;
+    end
 
     assert(grid.dim == 2, ...
            'curlOp_impl:InvalidDim', 'curl is only implemented for 2-D grids');

--- a/src/matlab_octave/operators/divergence/divOp_impl.m
+++ b/src/matlab_octave/operators/divergence/divOp_impl.m
@@ -1,4 +1,4 @@
-function D = divOp_impl(grid, k)
+function [D, err] = divOp_impl(grid, k)
 % PURPOSE
 % Grid-first mimetic divergence operator for 1-D, 2-D, and 3-D uniform grids.
 %
@@ -17,6 +17,11 @@ function D = divOp_impl(grid, k)
 % ----------------------------------------------------------------------------
 
     grid = validateGrid(grid);
+    err = grid.error;
+    if err.hasError
+        D = [];
+        return;
+    end
 
     assert(k >= 2, 'k >= 2');
     assert(mod(k, 2) == 0, 'k % 2 = 0');

--- a/src/matlab_octave/operators/gradient/gradOp_impl.m
+++ b/src/matlab_octave/operators/gradient/gradOp_impl.m
@@ -1,4 +1,4 @@
-function G = gradOp_impl(grid, k)
+function [G, err] = gradOp_impl(grid, k)
 % PURPOSE
 % Grid-first mimetic gradient operator for 1-D, 2-D, and 3-D uniform grids.
 %
@@ -17,6 +17,11 @@ function G = gradOp_impl(grid, k)
 % ----------------------------------------------------------------------------
 
     grid = validateGrid(grid);
+    err = grid.error;
+    if err.hasError
+        G = [];
+        return;
+    end
 
     assert(k >= 2, 'k >= 2');
     assert(mod(k, 2) == 0, 'k % 2 = 0');

--- a/src/matlab_octave/operators/nodal/nodalOp_impl.m
+++ b/src/matlab_octave/operators/nodal/nodalOp_impl.m
@@ -1,4 +1,4 @@
-function N = nodalOp_impl(grid, k)
+function [N, err] = nodalOp_impl(grid, k)
 % PURPOSE
 % Grid-first nodal derivative operator for 1-D, 2-D, and 3-D uniform grids.
 %
@@ -16,6 +16,11 @@ function N = nodalOp_impl(grid, k)
 % ----------------------------------------------------------------------------
 
     grid = validateGrid(grid, true);
+    err = grid.error;
+    if err.hasError
+        N = [];
+        return;
+    end
 
     assert(k >= 2, 'k >= 2');
     assert(mod(k, 2) == 0, 'k % 2 = 0');

--- a/tests/matlab_octave/testGridFirstV2Migration.m
+++ b/tests/matlab_octave/testGridFirstV2Migration.m
@@ -155,12 +155,17 @@ classdef testGridFirstV2Migration < matlab.unittest.TestCase
         function testValidateGridRejectsPartialBoundarySpec(testCase)
             addpath('../../src/matlab_octave');
 
-            testCase.verifyError(@() validateGrid(struct('m', 5, 'dx', 0.1, 'bc', struct('dc', 1))), ...
-                                 'validateGrid:InvalidBC1D');
-            testCase.verifyError(@() validateGrid(struct('m', 5, 'n', 6, 'dx', 0.1, 'dy', 0.2, 'bc', struct('dc', [1;1;1;1], 'nc', []))), ...
-                                 'validateGrid:InvalidBC2D');
-            testCase.verifyError(@() validateGrid(struct('m', 5, 'n', 6, 'o', 7, 'dx', 0.1, 'dy', 0.2, 'dz', 0.3, 'bc', struct('nc', 1))), ...
-                                 'validateGrid:InvalidBC3D');
+            g1 = validateGrid(struct('m', 5, 'dx', 0.1, 'bc', struct('dc', 1)));
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 104);
+
+            g2 = validateGrid(struct('m', 5, 'n', 6, 'dx', 0.1, 'dy', 0.2, 'bc', struct('dc', [1;1;1;1], 'nc', [])));
+            testCase.verifyTrue(g2.error.hasError);
+            testCase.verifyEqual(g2.error.code, 104);
+
+            g3 = validateGrid(struct('m', 5, 'n', 6, 'o', 7, 'dx', 0.1, 'dy', 0.2, 'dz', 0.3, 'bc', struct('nc', 1)));
+            testCase.verifyTrue(g3.error.hasError);
+            testCase.verifyEqual(g3.error.code, 104);
         end
 
         function testDeprecatedDimensionalOperatorsDeleted(testCase)
@@ -178,5 +183,24 @@ classdef testGridFirstV2Migration < matlab.unittest.TestCase
             testCase.verifyError(@() interpolD(10, 0.5),         'MATLAB:UndefinedFunction');
             testCase.verifyError(@() interpolCentersToFacesD1D(2, 10), 'MATLAB:UndefinedFunction');
         end
+
+        function testMakeGridRejectsOddNameValuePairs(testCase)
+            addpath('../../src/matlab_octave');
+            g1 = makeGrid('m');
+            testCase.verifyTrue(isstruct(g1));
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 100);
+            testCase.verifyEqual(g1.error.id, 'makeGrid:InvalidInput');
+        end
+
+        function testMakeGridRejectsInvalidFieldName(testCase)
+            addpath('../../src/matlab_octave');
+            g1 = makeGrid(123, 5);
+            testCase.verifyTrue(isstruct(g1));
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 100);
+            testCase.verifyEqual(g1.error.id, 'makeGrid:InvalidFieldName');
+        end
+
     end
 end

--- a/tests/matlab_octave/testGridFirstV2Migration.m
+++ b/tests/matlab_octave/testGridFirstV2Migration.m
@@ -202,5 +202,20 @@ classdef testGridFirstV2Migration < matlab.unittest.TestCase
             testCase.verifyEqual(g1.error.id, 'makeGrid:InvalidFieldName');
         end
 
+        function testOperatorsPropagateGridError(testCase)
+            addpath('../../src/matlab_octave');
+            % Invalid grid (uniform 1D missing dx -> code 103). Operators must
+            % return the error via the second output instead of throwing.
+            [G, gErr] = grad(struct('m', 5), 4);
+            testCase.verifyEmpty(G);
+            testCase.verifyTrue(gErr.hasError);
+            testCase.verifyEqual(gErr.code, 103);
+
+            [D, dErr] = div(struct('m', 5), 4);
+            testCase.verifyEmpty(D);
+            testCase.verifyTrue(dErr.hasError);
+            testCase.verifyEqual(dErr.code, 103);
+        end
+
     end
 end

--- a/tests/matlab_octave/testGridStruct.m
+++ b/tests/matlab_octave/testGridStruct.m
@@ -197,7 +197,9 @@ classdef testGridStruct < matlab.unittest.TestCase
             % (do NOT use makeGrid here, which would auto-populate nodes)
             grid = struct('m', m, 'n', n, 'dx', 0.5, 'dy', 0.25, ...
                           'type', 'curvilinear', 'dim', 2);
-            testCase.verifyError(@() validateGrid(grid), 'validateGrid:CurvilinearMissingNodes');
+            g1 = validateGrid(grid);
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 106);
         end
 
         function test2DNodeYSizeMismatchError(testCase)
@@ -208,7 +210,42 @@ classdef testGridStruct < matlab.unittest.TestCase
             grid = struct('m', m, 'n', n, 'dx', 1, 'dy', 1, ...
                           'type', 'curvilinear', ...
                           'nodes', struct('X', good_X, 'Y', bad_Y));
-            testCase.verifyError(@() validateGrid(grid), 'validateGrid:SizeMismatch');
+            g1 = validateGrid(grid);
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 107);
+        end
+
+        function testValidateGridRejectsNonStructInput(testCase)
+            addpath('../../src/matlab_octave');
+            g1 = validateGrid(5);
+            testCase.verifyTrue(isstruct(g1));
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 100);
+            testCase.verifyEqual(g1.error.id, 'validateGrid:InvalidInput');
+        end
+
+        function testValidateGridRejectsMissingDx(testCase)
+            addpath('../../src/matlab_octave');
+            g1 = validateGrid(struct('m', 5));
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 103);
+        end
+
+        function testValidateGridRejectsInvalidDim(testCase)
+            addpath('../../src/matlab_octave');
+            g1 = validateGrid(struct('dim', 4, 'm', 5, 'dx', 0.1));
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 102);
+        end
+
+        function testValidateGridRejectsBadBoundaryVectorSize(testCase)
+            addpath('../../src/matlab_octave');
+            grid = struct('m', 5, 'n', 6, 'dx', 0.1, 'dy', 0.2, ...
+                          'bc', struct('dc', [1; 1; 1], 'nc', [1; 1; 1]));
+            
+            g1 = validateGrid(grid);
+            testCase.verifyTrue(g1.error.hasError);
+            testCase.verifyEqual(g1.error.code, 105);
         end
 
     end  % methods(Test)


### PR DESCRIPTION
@Tony-Drummond 
## Summary
Replaces assert/error() calls in the MOLE 2.0 grid API with a returned
`grid.error` structure, so validation failures return control to the
caller instead of halting execution, and propagates that error out
through the operators.

## Grid error handling
- validateGrid_impl.m, makeGrid_impl.m: asserts/exceptions become grid.error returns
- addGridError.m (new): helper attaching a standard error struct
  (hasError, code, id, field, message)
- ERROR_CODES.md (new): grid error code table (codes 100-108)
- Grid tests updated to assert on the returned error codes

## Operator propagation
- grad, div, curl, nodal, interpol, addScalarBC (and their *Op_impl
  functions) gain a trailing `err` output.
- On an invalid grid they return an empty operator (inputs unchanged for
  addScalarBC) instead of proceeding, surfacing grid.error to the caller.
- Single-output calls (e.g. G = grad(grid, k)) are unaffected.
- Added a test asserting grad/div propagate a missing-dx error (code 103).

## Follow-ups
- Code 108 (periodic-BC conflict) still needs a dedicated test.
- Grid-structure refactor (separate nodal/face generation) is a proposal,
  not included here.

Refs #378, #370
