### PR TITLE
docs: add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![MATLAB File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/124870-mole)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Build Status](https://github.com/csrc-sdsu/mole/actions/workflows/ci.yml/badge.svg)](https://github.com/csrc-sdsu/mole/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/csrc-sdsu/mole/branch/main/graph/badge.svg)](https://codecov.io/gh/csrc-sdsu/mole)
 [![Documentation](https://readthedocs.org/projects/mole-docs/badge/?version=main)](https://mole-docs.readthedocs.io/en/main/)
 
 ## Description


### PR DESCRIPTION
Adds the Codecov badge requested in #403 to the README badge list.

I verified that both the badge image URL and the Codecov project page resolve successfully, and ran `git diff --check`.

Fixes #403.
