### PR TITLE
2D MOLE.jl julia interpolators

### DIFF
--- a/julia/MOLE.jl/docs/src/index.md
+++ b/julia/MOLE.jl/docs/src/index.md
@@ -99,7 +99,11 @@ MOLE.Operators.grad(k::Int, m::Int, dx, n::Int, dy; dc::NTuple{4,T}, nc::NTuple{
 MOLE.Operators.grad(k::Int, xticks::AbstractVector, yticks::AbstractVector)
 MOLE.Operators.lap(k::Int, m::Int, dx; dc::NTuple{2,T}, nc::NTuple{2,T})
 MOLE.Operators.lap(k::Int, m::Int, dx, n::Int, dy; dc::NTuple{4,T}, nc::NTuple{4,T})
-MOLE.Operators.interpol(m::Int, c::Float64)
+MOLE.Operators.interpol(m::Int, c::Real)
+MOLE.Operators.interpol(::Val{:centers_to_faces}, k::Int, m::Int)
+MOLE.Operators.interpol(::Val{:faces_to_centers}, k::Int, m::Int)
+MOLE.Operators.interpol(::Val{:centers_to_faces}, k::Int, m::Int, n::Int)
+MOLE.Operators.interpol(::Val{:faces_to_centers}, k::Int, m::Int, n::Int)
 ```
 
 ### Utilities

--- a/julia/MOLE.jl/src/Operators/interpol.jl
+++ b/julia/MOLE.jl/src/Operators/interpol.jl
@@ -1,42 +1,175 @@
-using SparseArrays
 #=
         SPDX-License-Identifier: GPL-3.0-or-later
         © 2008-2024 San Diego State University Research Foundation (SDSURF).
         See LICENSE file or https://www.gnu.org/licenses/gpl-3.0.html for details.
 =#
 
+using SparseArrays
 
 """
-    interpol(m, c)
+    interpol(m::Int, c::Real)
 
-Returns a (m+1)×(m+2) one-dimensional interpolator of 2nd-order
+Construct the one-dimensional center-to-face interpolation operator.
 
-# Arguments
-- `m::Int`  : number of cells
-- `c::Float`: left interpolation coefficient
+Returns a sparse `(m+1) × (m+2)` matrix.
 """
-function interpol(m::Int, c::Float64)
+function interpol(m::Int, c::Real)
+    @assert m ≥ 4 "m must be at least 4."
+    @assert 0 ≤ c ≤ 1 "Interpolation weight must satisfy 0 ≤ c ≤ 1."
 
-    #Assertions:
-    @assert m>=4 ["m >= 4"];
-    @assert c >= 0 && c <= 1 ["0 <= c <= 1"];
+    rows = Int[]
+    cols = Int[]
+    vals = Float64[]
 
-    #Dimensions of I:
-    n_rows = m+1;
-    n_cols = m+2;
+    push!(rows, 1)
+    push!(cols, 1)
+    push!(vals, 1.0)
 
-    I = zeros(n_rows, n_cols);
+    for i in 2:m
+        push!(rows, i)
+        push!(cols, i)
+        push!(vals, Float64(c))
 
-    I[1, 1] = 1;
-    I[end, end]=1;
-
-    #Average between two continuous cells
-    avg = [c 1-c];
-
-    j = 2;
-    for i in 2:(n_rows - 1)
-        I[i, j:(j + 2 - 1)] = avg;
-        j = j + 1;
+        push!(rows, i)
+        push!(cols, i + 1)
+        push!(vals, Float64(1 - c))
     end
-    return I
+
+    push!(rows, m + 1)
+    push!(cols, m + 2)
+    push!(vals, 1.0)
+
+    return sparse(rows, cols, vals, m + 1, m + 2)
+end
+
+"""
+    interpol(::Val{:centers_to_faces}, k::Int, m::Int; c=0.5)
+
+Construct the one-dimensional center-to-face interpolation operator.
+
+This is equivalent to `interpol(m, c)` for `k == 2`.
+"""
+function interpol(::Val{:centers_to_faces}, k::Int, m::Int; c::Real = 0.5)
+    @assert k == 2 "Only k == 2 is currently implemented."
+    return interpol(m, c)
+end
+
+"""
+    interpol(::Val{:faces_to_centers}, k::Int, m::Int; c=0.5)
+
+Construct the one-dimensional face-to-center interpolation operator.
+
+Returns a sparse `(m+2) × (m+1)` matrix.
+"""
+function interpol(::Val{:faces_to_centers}, k::Int, m::Int; c::Real = 0.5)
+    @assert k == 2 "Only k == 2 is currently implemented."
+    @assert m ≥ 4 "m must be at least 4."
+    @assert 0 ≤ c ≤ 1 "Interpolation weight must satisfy 0 ≤ c ≤ 1."
+
+    rows = Int[]
+    cols = Int[]
+    vals = Float64[]
+
+    push!(rows, 1)
+    push!(cols, 1)
+    push!(vals, 1.0)
+
+    for i in 2:(m + 1)
+        push!(rows, i)
+        push!(cols, i - 1)
+        push!(vals, Float64(c))
+
+        push!(rows, i)
+        push!(cols, i)
+        push!(vals, Float64(1 - c))
+    end
+
+    push!(rows, m + 2)
+    push!(cols, m + 1)
+    push!(vals, 1.0)
+
+    return sparse(rows, cols, vals, m + 2, m + 1)
+end
+
+function _interior_embedding(q::Int)
+    rows = collect(2:(q + 1))
+    cols = collect(1:q)
+    vals = ones(Float64, q)
+
+    return sparse(rows, cols, vals, q + 2, q)
+end
+
+"""
+    interpol(::Val{:centers_to_faces}, k::Int, m::Int, n::Int; c=0.5)
+
+Construct the two-dimensional center-to-face interpolation operator.
+
+Maps duplicated cell-centered data `[u; u]` to staggered face data
+
+    [u_x_faces;
+     u_y_faces]
+
+with size `((m+1)n + m(n+1)) × 2(m+2)(n+2)`.
+"""
+function interpol(
+    ::Val{:centers_to_faces},
+    k::Int,
+    m::Int,
+    n::Int;
+    c::Real = 0.5,
+)
+    @assert k == 2 "Only k == 2 is currently implemented."
+    @assert m ≥ 4 "m must be at least 4."
+    @assert n ≥ 4 "n must be at least 4."
+
+    Ix = interpol(Val(:centers_to_faces), k, m; c = c)
+    Iy = interpol(Val(:centers_to_faces), k, n; c = c)
+
+    Im = _interior_embedding(m)
+    In = _interior_embedding(n)
+
+    Sx = kron(transpose(In), Ix)
+    Sy = kron(Iy, transpose(Im))
+
+    return blockdiag(Sx, Sy)
+end
+
+"""
+    interpol(::Val{:faces_to_centers}, k::Int, m::Int, n::Int; c=0.5)
+
+Construct the two-dimensional face-to-center interpolation operator.
+
+Maps staggered face data
+
+    [g_x_faces;
+     g_y_faces]
+
+to duplicated cell-centered data
+
+    [g_x_centers;
+     g_y_centers]
+
+with size `2(m+2)(n+2) × ((m+1)n + m(n+1))`.
+"""
+function interpol(
+    ::Val{:faces_to_centers},
+    k::Int,
+    m::Int,
+    n::Int;
+    c::Real = 0.5,
+)
+    @assert k == 2 "Only k == 2 is currently implemented."
+    @assert m ≥ 4 "m must be at least 4."
+    @assert n ≥ 4 "n must be at least 4."
+
+    Ix = interpol(Val(:faces_to_centers), k, m; c = c)
+    Iy = interpol(Val(:faces_to_centers), k, n; c = c)
+
+    Im = _interior_embedding(m)
+    In = _interior_embedding(n)
+
+    Sx = kron(In, Ix)
+    Sy = kron(Iy, Im)
+
+    return blockdiag(Sx, Sy)
 end

--- a/julia/MOLE.jl/test/Operators/interpol.jl
+++ b/julia/MOLE.jl/test/Operators/interpol.jl
@@ -1,13 +1,199 @@
 tol = 1e-10
 
-@testset "Testing interpolator operator for m=5 and c=$c" for c in 0:0.25:1
+@testset "Testing 1D center-to-face interpolator" begin
     m = 5
-    I = Operators.interpol(m, c)
-    A = [1 0 0 0 0 0 0;
-        0 c 1-c 0 0 0 0;
-        0 0 c 1-c 0 0 0;
-        0 0 0 c 1-c 0 0;
-        0 0 0 0 c 1-c 0;
-        0 0 0 0 0 0 1]
-    @test norm(I-A) < tol
+
+    for c in 0:0.25:1
+        I = Operators.interpol(m, c)
+
+        A = [
+            1 0 0 0 0 0 0
+            0 c 1-c 0 0 0 0
+            0 0 c 1-c 0 0 0
+            0 0 0 c 1-c 0 0
+            0 0 0 0 c 1-c 0
+            0 0 0 0 0 0 1
+        ]
+
+        @test size(I) == (m + 1, m + 2)
+        @test issparse(I)
+        @test norm(Matrix(I) - A) < tol
+    end
+end
+
+@testset "Testing 1D face-to-center interpolator" begin
+    m = 5
+
+    for c in 0:0.25:1
+        I = Operators.interpol(Val(:faces_to_centers), 2, m; c = c)
+
+        A = [
+            1 0 0 0 0 0
+            c 1-c 0 0 0 0
+            0 c 1-c 0 0 0
+            0 0 c 1-c 0 0
+            0 0 0 c 1-c 0
+            0 0 0 0 c 1-c
+            0 0 0 0 0 1
+        ]
+
+        @test size(I) == (m + 2, m + 1)
+        @test issparse(I)
+        @test norm(Matrix(I) - A) < tol
+    end
+end
+
+@testset "Testing 2D interpolators" begin
+    k = 2
+    m = 7
+    n = 6
+
+    a = 0.0
+    b = 1.0
+    y0 = 0.0
+    y1 = 1.0
+
+    dx = (b - a) / m
+    dy = (y1 - y0) / n
+
+    Ncell = (m + 2) * (n + 2)
+    Nxfaces = (m + 1) * n
+    Nyfaces = m * (n + 1)
+    Nfaces = Nxfaces + Nyfaces
+
+    x = range(a - dx / 2, b + dx / 2, length = m + 2)
+    y = range(y0 - dy / 2, y1 + dy / 2, length = n + 2)
+
+    X = repeat(collect(x), 1, n + 2)
+    Y = repeat(collect(y)', m + 2, 1)
+
+    I = Operators.interpol(Val(:centers_to_faces), k, m, n)
+    II = Operators.interpol(Val(:faces_to_centers), k, m, n)
+    G = Operators.grad(k, m, dx, n, dy)
+
+    @testset "dimensions and sparsity" begin
+        @test size(I) == (Nfaces, 2Ncell)
+        @test size(II) == (2Ncell, Nfaces)
+        @test size(II * G) == (2Ncell, Ncell)
+
+        @test issparse(I)
+        @test issparse(II)
+    end
+
+    @testset "center-to-face preserves constants" begin
+        u = ones(Ncell)
+        out = I * [u; u]
+
+        @test length(out) == Nfaces
+        @test all(out .≈ 1.0)
+    end
+
+    @testset "center-to-face interpolates linear x field" begin
+        u = vec(X)
+        out = I * [u; u]
+
+        ux_faces = reshape(out[1:Nxfaces], m + 1, n)
+        uy_faces = reshape(out[(Nxfaces + 1):end], m, n + 1)
+
+        x_on_x_faces = [
+            a - dx / 2
+            collect(range(a + dx, b - dx, length = m - 1))
+            b + dx / 2
+        ]
+
+        x_on_y_faces = collect(range(a + dx / 2, b - dx / 2, length = m))
+
+        @test all(ux_faces .≈ repeat(x_on_x_faces, 1, n))
+        @test all(uy_faces .≈ repeat(x_on_y_faces, 1, n + 1))
+    end
+
+    @testset "center-to-face interpolates linear y field" begin
+        u = vec(Y)
+        out = I * [u; u]
+
+        ux_faces = reshape(out[1:Nxfaces], m + 1, n)
+        uy_faces = reshape(out[(Nxfaces + 1):end], m, n + 1)
+
+        y_on_x_faces = collect(range(y0 + dy / 2, y1 - dy / 2, length = n))
+
+        y_on_y_faces = [
+            y0 - dy / 2
+            collect(range(y0 + dy, y1 - dy, length = n - 1))
+            y1 + dy / 2
+        ]
+
+        @test all(ux_faces .≈ repeat(y_on_x_faces', m + 1, 1))
+        @test all(uy_faces .≈ repeat(y_on_y_faces', m, 1))
+    end
+
+    @testset "face-to-center preserves constants on valid component domains" begin
+        gx = ones(Nxfaces)
+        gy = ones(Nyfaces)
+
+        out = II * [gx; gy]
+
+        ux = reshape(out[1:Ncell], m + 2, n + 2)
+        uy = reshape(out[(Ncell + 1):end], m + 2, n + 2)
+
+        # x-component is defined on all x rows, interior y columns.
+        @test all(ux[:, 1] .≈ 0.0)
+        @test all(ux[:, n + 2] .≈ 0.0)
+        @test all(ux[:, 2:(n + 1)] .≈ 1.0)
+
+        # y-component is defined on interior x rows, all y columns.
+        @test all(uy[1, :] .≈ 0.0)
+        @test all(uy[m + 2, :] .≈ 0.0)
+        @test all(uy[2:(m + 1), :] .≈ 1.0)
+    end
+
+    @testset "gradient composition annihilates constant pressure" begin
+        p = ones(Ncell)
+        correction = II * G * p
+
+        @test length(correction) == 2Ncell
+        @test norm(correction) < tol
+    end
+
+    @testset "gradient composition differentiates linear x pressure" begin
+        p = vec(X)
+        correction = II * G * p
+
+        px = reshape(correction[1:Ncell], m + 2, n + 2)
+        py = reshape(correction[(Ncell + 1):end], m + 2, n + 2)
+
+        # Away from x-boundary closure rows, d(x)/dx = 1.
+        @test all(px[3:m, 2:(n + 1)] .≈ 1.0)
+
+        # Cross derivative d(x)/dy = 0 on the valid y-component domain.
+        @test norm(py[2:(m + 1), :]) < tol
+    end
+
+    @testset "gradient composition differentiates linear y pressure" begin
+        p = vec(Y)
+        correction = II * G * p
+
+        px = reshape(correction[1:Ncell], m + 2, n + 2)
+        py = reshape(correction[(Ncell + 1):end], m + 2, n + 2)
+
+        # Cross derivative d(y)/dx = 0 on the valid x-component domain.
+        @test norm(px[:, 2:(n + 1)]) < tol
+
+        # Away from y-boundary closure columns, d(y)/dy = 1.
+        @test all(py[2:(m + 1), 3:n] .≈ 1.0)
+    end
+end
+
+@testset "Testing interpolator argument validation" begin
+    @test_throws AssertionError Operators.interpol(3, 0.5)
+    @test_throws AssertionError Operators.interpol(5, -0.1)
+    @test_throws AssertionError Operators.interpol(5, 1.1)
+
+    @test_throws AssertionError Operators.interpol(Val(:centers_to_faces), 4, 7)
+    @test_throws AssertionError Operators.interpol(Val(:faces_to_centers), 4, 7)
+
+    @test_throws AssertionError Operators.interpol(Val(:centers_to_faces), 2, 3, 6)
+    @test_throws AssertionError Operators.interpol(Val(:centers_to_faces), 2, 7, 3)
+
+    @test_throws AssertionError Operators.interpol(Val(:faces_to_centers), 2, 3, 6)
+    @test_throws AssertionError Operators.interpol(Val(:faces_to_centers), 2, 7, 3)
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
This PR adds 2D MOLE.jl interpolator operators, keeping the API consistent in a "Julian" way (that is, using dynamic multiple dispatch for the different dimensional cases). It implements 2D interpolators as the tensor-product `kron` of 1D interpolators (to match the Octave/MATLAB implementation). It also adds related tests and documentation.

## Related Issues & Documents

- [x] I have created an Issue that is paired with this PR
- Closes #423 


## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [x] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [x] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md
