### PR TITLE
MATLAB_OCTAVE now just Octave in docs.

### DIFF
--- a/COMMUNITY_ROLES.md
+++ b/COMMUNITY_ROLES.md
@@ -54,7 +54,7 @@ Users are all members from industry and academia who are using MOLE to implement
 
 ## MOLE OSE Curious
 
-Anyone with an interest in **_Mimetic Discretization_** and the fast prototyping of numerical solutions using MOLE from Matlab, C++ or Python. Individuals interested in knowing more about MOLE should sign up for our mailing lists, check the [MOLE website](https://mole-docs.readthedocs.io/) and [GitHub repository](https://github.com/csrc-sdsu/mole), where anyone can check MOLE forums.
+Anyone with an interest in **_Mimetic Discretization_** and the fast prototyping of numerical solutions using MOLE from Octave, C++ or Python. Individuals interested in knowing more about MOLE should sign up for our mailing lists, check the [MOLE website](https://mole-docs.readthedocs.io/) and [GitHub repository](https://github.com/csrc-sdsu/mole), where anyone can check MOLE forums.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Thank you for considering contributing to MOLE (Mimetic Operators Library Enhanc
 
 Before contributing, ensure you have:
 
-- **For MATLAB/Octave**: MATLAB R2016b+ or GNU Octave 4.0+
+- **For Octave**: MATLAB R2016b+ or GNU Octave 4.0+
 - **For C++**: CMake 3.10+, OpenBLAS, Eigen3, Armadillo
 - **For Documentation**: Python 3.7+, Sphinx, Doxygen
 
@@ -55,9 +55,9 @@ Core functionality includes mimetic operators, boundary conditions, and utility 
 
 ### Core API Structure
 
-The MOLE library follows a consistent structure across MATLAB and C++ implementations:
+The MOLE library follows a consistent structure across Octave and C++ implementations:
 
-#### MATLAB/Octave Core Functions
+#### Octave Core Functions
 
 Core functions are located in `src/matlab_octave/` and follow this pattern:
 
@@ -157,7 +157,7 @@ When contributing core functionality, identify which category your contribution 
 
 If adding a new operator, follow this checklist:
 
-1. **MATLAB Implementation** (`src/matlab_octave/newoperator.m`):
+1. **Octave Implementation** (`src/matlab_octave/newoperator.m`):
    ```matlab
    function OP = newoperator(k, m, dx)
    % Returns a new mimetic operator
@@ -195,7 +195,7 @@ Examples are organized by PDE type in the `examples/` directory:
 
 ```
 examples/
-├── matlab_octave/         # MATLAB/Octave examples
+├── matlab_octave/         # Octave examples
 │   ├── elliptic1D.m       # Basic examples
 │   ├── parabolic2D.m      # 2D examples
 │   └── compact_operators/ # Specialized examples
@@ -214,7 +214,7 @@ Organize your examples by PDE type:
 4. **Mixed**: Problems involving multiple PDE types
 5. **Specialized**: Navier-Stokes, Schrödinger, etc.
 
-### MATLAB/Octave Example Template
+### Octave Example Template
 
 ```matlab
 % Solves the [EQUATION NAME] with [BOUNDARY CONDITIONS]
@@ -404,7 +404,7 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/example_name.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/example_name.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/example_name.cpp) *(if available)*
 
 #### Variants
@@ -426,7 +426,7 @@ Additional variants with different boundary conditions or parameters:
 
 ## Code Standards and Guidelines
 
-### MATLAB/Octave Standards
+### Octave Standards
 
 1. **Function Names**: Use descriptive names following the existing convention
 2. **Variable Names**: Use clear, descriptive variable names
@@ -469,7 +469,7 @@ Additional variants with different boundary conditions or parameters:
 1. **Analytical Solutions**: Compare with known exact solutions
 2. **Convergence Studies**: Verify theoretical order of accuracy
 3. **Conservation Laws**: Check that operators preserve conservation properties
-4. **Cross-platform Testing**: Test on both MATLAB and Octave (for MATLAB code)
+4. **Cross-platform Testing**: Test on both MATLAB and Octave (for Octave code)
 
 ### Performance Considerations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Thank you for considering contributing to MOLE (Mimetic Operators Library Enhanc
 
 Before contributing, ensure you have:
 
-- **For Octave**: MATLAB R2016b+ or GNU Octave 4.0+
+- **For Octave**: GNU Octave 4.0+ (optional: MATLAB R2016b+)
 - **For C++**: CMake 3.10+, OpenBLAS, Eigen3, Armadillo
 - **For Documentation**: Python 3.7+, Sphinx, Doxygen
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-MOLE is a high-quality (C++, MATLAB/Octave, and Julia) library that implements
+MOLE is a high-quality (C++, Octave, and Julia) library that implements
 high-order mimetic operators to solve partial differential equations.
 It provides discrete analogs of the most common vector calculus operators:
 Gradient, Divergence, Laplacian, Bilaplacian, and Curl. These operators (highly sparse matrices) act
@@ -121,9 +121,9 @@ A suite of four automatic tests that verify MOLE's installation and dependencies
 make run_tests
 ```
 
-### MATLAB/Octave
+### Octave
 
-MATLAB/Octave equivalent of the C++ test suite. We recommend running these tests before using MOLE to ensure proper setup.
+Octave equivalent of the C++ test suite. We recommend running these tests before using MOLE to ensure proper setup.
 
 ```matlab
 make run_matlab_octave_tests
@@ -141,7 +141,7 @@ and on Windows downlaoding and running the file from [here](https://sourceforge.
 
 There are several self-contained, well-documented examples demonstrating typical PDE solutions. These are automatically built with `make` and serve as an excellent starting point for C++ users.
 
-### MATLAB/Octave Examples
+### Octave Examples
 
 A collection of over 30 examples showcasing various PDE solutions, from simple linear one-dimensional problems to complex nonlinear multidimensional scenarios.
 

--- a/doc/sphinx/README.md
+++ b/doc/sphinx/README.md
@@ -8,7 +8,7 @@ The MOLE documentation consists of two main components:
 
 1. **API Documentation** (Doxygen)
    - C++ API reference
-   - MATLAB/Octave API reference
+   - Octave API reference
    - Implementation details
    - Code documentation
 

--- a/doc/sphinx/source/api/matlab_octave/api.rst
+++ b/doc/sphinx/source/api/matlab_octave/api.rst
@@ -1,8 +1,8 @@
 =========================================
-MATLAB/Octave API
+Octave API
 =========================================
 
-This page documents the API of the MOLE MATLAB/Octave module. Functions are organized by category.
+This page documents the API of the MOLE Octave module. Functions are organized by category.
 
 .. mat:currentmodule:: .
 

--- a/doc/sphinx/source/api/matlab_octave/index-beta.rst
+++ b/doc/sphinx/source/api/matlab_octave/index-beta.rst
@@ -1,15 +1,15 @@
 =========================================
-MATLAB/Octave
+Octave
 =========================================
 
-This section documents the MATLAB/Octave implementation of the MOLE toolkit.
-The documentation is generated automatically from the docstrings in the MATLAB/Octave source files.
+This section documents the Octave implementation of the MOLE toolkit.
+The documentation is generated automatically from the docstrings in the Octave source files.
 
 .. only:: html
 
     .. graphviz::
 
-        digraph "MOLE MATLAB Functions" {
+        digraph "MOLE Octave Functions" {
             rankdir=LR;
             compound=true;
             node [shape=box, style=filled, fontname="Arial", fontsize=10, margin="0.3,0.1"];
@@ -124,7 +124,7 @@ The documentation is generated automatically from the docstrings in the MATLAB/O
     Function Categories
     -------------------------
 
-    The MOLE MATLAB/Octave API consists of several main categories:
+    The MOLE Octave API consists of several main categories:
 
     * **Differential Operators**: Core operators for gradient, divergence, curl, and Laplacian calculations
     * **Interpolation Operators**: Functions for interpolating values between different grid locations

--- a/doc/sphinx/source/api/matlab_octave/matlab_index.rst
+++ b/doc/sphinx/source/api/matlab_octave/matlab_index.rst
@@ -1,7 +1,7 @@
-MATLAB/Octave Function Index
+Octave Function Index
 =========================================
 
-This page provides an index of all MATLAB/Octave functions in the MOLE library.
+This page provides an index of all Octave functions in the MOLE library.
 
 Gradient Operators
 ----------------------------

--- a/doc/sphinx/source/dev-notes/RELEASING.md
+++ b/doc/sphinx/source/dev-notes/RELEASING.md
@@ -26,7 +26,7 @@ While doing this, gather a couple sentences for key features to highlight on [Gi
 
 1. **Testing**: Ensure all tests pass on supported platforms:
    - Run `make run_tests` for C++ tests
-   - Run `make run_matlab_octave_tests` for Octave tests
+   - Run `make run_matlab_octave_tests` for Octave/MATLAB tests
    - Verify CI passes on all platforms (Ubuntu, macOS)
 
 2. **Documentation**: Ensure documentation builds successfully:

--- a/doc/sphinx/source/dev-notes/RELEASING.md
+++ b/doc/sphinx/source/dev-notes/RELEASING.md
@@ -26,7 +26,7 @@ While doing this, gather a couple sentences for key features to highlight on [Gi
 
 1. **Testing**: Ensure all tests pass on supported platforms:
    - Run `make run_tests` for C++ tests
-   - Run `make run_matlab_octave_tests` for MATLAB/Octave tests
+   - Run `make run_matlab_octave_tests` for Octave tests
    - Verify CI passes on all platforms (Ubuntu, macOS)
 
 2. **Documentation**: Ensure documentation builds successfully:

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Homogeneous-Dirichlet.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Homogeneous-Dirichlet.md
@@ -40,10 +40,10 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/elliptic1DHomogeneousDirichlet.cpp)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)
 - [Left Dirichlet, Right Robin](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftDirichletRightRobin.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Dirichlet-Right-Robin.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Dirichlet-Right-Robin.md
@@ -46,9 +46,9 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftDirichletRightRobin.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftDirichletRightRobin.m)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Neumann-Right-Dirichlet.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Neumann-Right-Dirichlet.md
@@ -43,10 +43,10 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/elliptic1DLeftNeumannRightDirichlet.cpp)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Dirichlet, Right Robin](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftDirichletRightRobin.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Neumann-Right-Neumann.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Neumann-Right-Neumann.md
@@ -46,10 +46,10 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightNeumann.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightNeumann.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/elliptic1DLeftNeumannRightNeumann.cpp)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Neumann-Right-Robin.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Neumann-Right-Robin.md
@@ -49,9 +49,9 @@ The example is taken from [this paper](https://www.scirp.org/journal/paperinform
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightRobin.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightRobin.m)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Robin-Right-Robin.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Left-Robin-Right-Robin.md
@@ -48,9 +48,9 @@ The example is taken from [this paper](https://www.scirp.org/journal/paperinform
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNRobinRightRobin.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNRobinRightRobin.m)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Non-Homogeneous-Dirichlet.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Non-Homogeneous-Dirichlet.md
@@ -40,10 +40,10 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/elliptic1DNonHomogeneousDirichlet.cpp)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)
 - [Left Dirichlet, Right Robin](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftDirichletRightRobin.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Non-Periodic-BC.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Non-Periodic-BC.md
@@ -43,9 +43,9 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonPeriodicBC.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonPeriodicBC.m)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Periodic-BC.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D-Periodic-BC.md
@@ -32,9 +32,9 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DPeriodicBC.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DPeriodicBC.m)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D.md
+++ b/doc/sphinx/source/examples/Elliptic/1D/Elliptic1D.md
@@ -27,10 +27,10 @@ This corresponds to the call to robinBC1D of `robinBC1D(k, m, dx, a, b)`.
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1D.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/elliptic1D.cpp)
 
-Additional MATLAB/ OCTAVE variants of this example with different boundary conditions:
+Additional Octave variants of this example with different boundary conditions:
 - [Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DHomogeneousDirichlet.m)
 - [Non-Homogeneous Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DNonHomogeneousDirichlet.m)
 - [Left Neumann, Right Dirichlet](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1DLeftNeumannRightDirichlet.m)

--- a/doc/sphinx/source/examples/Elliptic/2D/Elliptic2D-Nodal-Curv-Sinusoidal.md
+++ b/doc/sphinx/source/examples/Elliptic/2D/Elliptic2D-Nodal-Curv-Sinusoidal.md
@@ -22,4 +22,4 @@ au + b\nabla u = g
 $$
 
 with $a=1$, $b=0$, and $g=0$, which is equivalent to Dirichlet conditions along each boundary.
-The MATLAB/ OCTAVE code uses the function `boundaryIdx2D` to find the correct locations for the weights of the boundary condition in the Laplacian node. The code then sets the appropriate values to $0$ or $1$.
+The Octave code uses the function `boundaryIdx2D` to find the correct locations for the weights of the boundary condition in the Laplacian node. The code then sets the appropriate values to $0$ or $1$.

--- a/doc/sphinx/source/examples/Elliptic/2D/Elliptic2D-Nodal-Curv.md
+++ b/doc/sphinx/source/examples/Elliptic/2D/Elliptic2D-Nodal-Curv.md
@@ -21,4 +21,4 @@ $$
 au + b\nabla u = g
 $$
 
-The MATLAB/ OCTAVE code uses the function `boundaryIdx2D` to find the correct locations for boundary condition weights in the nodal Laplacian. The code then sets the appropriate values to $0$ or $1$.
+The Octave code uses the function `boundaryIdx2D` to find the correct locations for boundary condition weights in the nodal Laplacian. The code then sets the appropriate values to $0$ or $1$.

--- a/doc/sphinx/source/examples/Hyperbolic/1D/Burgers1D.md
+++ b/doc/sphinx/source/examples/Hyperbolic/1D/Burgers1D.md
@@ -17,5 +17,5 @@ The wave is allowed to propagate across the domain while the area under the curv
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/burgers1D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/burgers1D.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/burgers1D.cpp) 

--- a/doc/sphinx/source/examples/Hyperbolic/1D/Hyperbolic1D.md
+++ b/doc/sphinx/source/examples/Hyperbolic/1D/Hyperbolic1D.md
@@ -41,8 +41,8 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/hyperbolic1D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/hyperbolic1D.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/hyperbolic1D.cpp)
-Additional MATLAB/ OCTAVE variants:
+Additional Octave variants:
 - [Upwind Scheme](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/hyperbolic1D_upwind.m)
 - [Lax-Friedrichs Scheme](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/hyperbolic1D_lax_friedrichs.m)

--- a/doc/sphinx/source/examples/Hyperbolic/1D/Wave-1D.md
+++ b/doc/sphinx/source/examples/Hyperbolic/1D/Wave-1D.md
@@ -19,8 +19,8 @@ $$
 ---
 
 This example is implemented in:
-- [MATLAB/ OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/wave1D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/wave1D.m)
 
-Additional MATLAB/ OCTAVE variants:
+Additional Octave variants:
 - [Wave 1D Case 2](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/wave1D_case2.m)
 - [Wave 1D with Time-Varying BC](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/wave1DTimeVaryingBC.m)

--- a/doc/sphinx/source/examples/Integration/Integration1D.md
+++ b/doc/sphinx/source/examples/Integration/Integration1D.md
@@ -88,8 +88,8 @@ $$
 3. Approximate the integral weights Q
 4. Set the boundary conditions at the ends
 5. Multiply weights * f to get estimate of the integral
-6. Compare to MATLAB trapz and integral functions
+6. Compare to Octave trapz and integral functions
 
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/integration1D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/integration1D.m)

--- a/doc/sphinx/source/examples/Mixed/3D/Convection-Diffusion.md
+++ b/doc/sphinx/source/examples/Mixed/3D/Convection-Diffusion.md
@@ -42,7 +42,7 @@ Time step constraints include:
 ---
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/convection_diffusion3D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/convection_diffusion3D.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/convection_diffusion3D.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Navier-Stokes/Cylinder-Flow-2D.md
+++ b/doc/sphinx/source/examples/Navier-Stokes/Cylinder-Flow-2D.md
@@ -106,7 +106,7 @@ During the pressure Poisson step,
 
 A projection method is used to enforce incompressibility.
 
-This is the same overall time-stepping strategy used in both the MATLAB/Octave and C++ implementations.
+This is the same overall time-stepping strategy used in both the Octave and C++ implementations.
 
 ### Time Integration
 
@@ -187,9 +187,9 @@ cd <mole-repo>/examples/cpp
 ../../build/examples/cpp/cylinder_flow_2D
 ```
 
-## MATLAB and C++ Versions
+## Octave and C++ Versions
 
-MATLAB/Octave and C++ versions of this example are provided with the same problem setup and the same overall projection-method structure. In particular, both versions use
+Octave and C++ versions of this example are provided with the same problem setup and the same overall projection-method structure. In particular, both versions use
 
 - AB2 for the convective term
 - AB1 at the first step
@@ -204,6 +204,6 @@ This makes it easier to compare the two implementations and to see how the same 
 
 ![C++ final fields](figures/cylinder_flow_2D_plot_cpp.png)
 
-### MATLAB result
+### Octave result
 
-![MATLAB final fields](figures/cylinder_flow_2D_plot_matlab.png)
+![Octave final fields](figures/cylinder_flow_2D_plot_matlab.png)

--- a/doc/sphinx/source/examples/Navier-Stokes/Lock-Exchange.md
+++ b/doc/sphinx/source/examples/Navier-Stokes/Lock-Exchange.md
@@ -43,7 +43,7 @@ Spatial discretization uses mimetic operators:
 ---
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/lock_exchange.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/lock_exchange.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/lock_exchange.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Parabolic/1D/Parabolic1D.md
+++ b/doc/sphinx/source/examples/Parabolic/1D/Parabolic1D.md
@@ -26,7 +26,7 @@ $$\Delta t \leq \frac{\Delta x^2}{3\alpha}$$
 ---
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/parabolic1D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/parabolic1D.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/parabolic1D.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Parabolic/1D/Terzaghi1D.md
+++ b/doc/sphinx/source/examples/Parabolic/1D/Terzaghi1D.md
@@ -70,4 +70,4 @@ At selected time snapshots (1, 10, 40, 70 hours), the following are printed and 
 #### Code Location
 
 This example is implemented in:  
-- [MATLAB/ OCTAVE (terzaghi1D.m)](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/terzaghi1D.m)
+- [Octave (terzaghi1D.m)](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/terzaghi1D.m)

--- a/doc/sphinx/source/examples/Parabolic/2D/Parabolic2D.md
+++ b/doc/sphinx/source/examples/Parabolic/2D/Parabolic2D.md
@@ -37,7 +37,7 @@ The explicit scheme requires a sufficiently small time step for stability.
 ---
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/parabolic2D.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/parabolic2D.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/parabolic2D.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Sturm-Liouville/Bessel.md
+++ b/doc/sphinx/source/examples/Sturm-Liouville/Bessel.md
@@ -44,7 +44,7 @@ Boundary conditions are applied using `RobinBC`.
 
 This example is implemented in:
 
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleBessel.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleBessel.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleBessel.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Sturm-Liouville/Chebyshev.md
+++ b/doc/sphinx/source/examples/Sturm-Liouville/Chebyshev.md
@@ -44,7 +44,7 @@ Boundary conditions are applied using the `addScalarBC1D` function.
 
 This example is implemented in:
 
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleChebyshev.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleChebyshev.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleChebyshev.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Sturm-Liouville/Helmholtz.md
+++ b/doc/sphinx/source/examples/Sturm-Liouville/Helmholtz.md
@@ -46,12 +46,12 @@ Boundary conditions are applied using `RobinBC` or `MixedBC`.
 
 These examples are implemented in:
 
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleHelmholtzDirichletDirichlet.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleHelmholtzDirichletDirichlet.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleHelmholtzDirichletDirichlet.cpp)
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleHelmholtzDirichletRobin.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleHelmholtzDirichletRobin.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleHelmholtzDirichletRobin.cpp)
-Additional MATLAB/OCTAVE and C++ variant:
-- [MATLAB/OCTAVE Wifi](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/helmholtz2D_wifi.m)
+Additional Octave and C++ variant:
+- [Octave Wifi](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/helmholtz2D_wifi.m)
 - [C++ Wifi](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/helmholtz2D_wifi.cpp)
 ## Results
 

--- a/doc/sphinx/source/examples/Sturm-Liouville/Hermite.md
+++ b/doc/sphinx/source/examples/Sturm-Liouville/Hermite.md
@@ -44,7 +44,7 @@ Boundary conditions are applied using `RobinBC`.
 
 This example is implemented in:
 
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleHermite.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleHermite.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleHermite.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Sturm-Liouville/Laguerre.md
+++ b/doc/sphinx/source/examples/Sturm-Liouville/Laguerre.md
@@ -44,7 +44,7 @@ Boundary conditions are applied using `RobinBC`.
 
 This example is implemented in:
 
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleLaguerre.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleLaguerre.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleLaguerre.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Sturm-Liouville/Legendre.md
+++ b/doc/sphinx/source/examples/Sturm-Liouville/Legendre.md
@@ -44,7 +44,7 @@ Boundary conditions are applied using `RobinBC`.
 
 This example is implemented in:
 
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleLegendre.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/sturmLiouvilleLegendre.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/sturmLiouvilleLegendre.cpp)
 
 ## Results

--- a/doc/sphinx/source/examples/Time-Integrators/RK2.md
+++ b/doc/sphinx/source/examples/Time-Integrators/RK2.md
@@ -36,7 +36,7 @@ where:
 - $y_i$ is the solution at time $t_i$
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/RK2.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/RK2.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/RK2.cpp)
 
-Both implementations include visualization of the solution using plotting tools (MATLAB's built-in plot function and GNUplot for C++). 
+Both implementations include visualization of the solution using plotting tools (Octave's built-in plot function and GNUplot for C++). 

--- a/doc/sphinx/source/examples/Time-Integrators/RK4.md
+++ b/doc/sphinx/source/examples/Time-Integrators/RK4.md
@@ -36,7 +36,7 @@ $$y(t) = y_0 \exp\left(\int_0^t \sin^2(s) ds\right) = y_0 \exp\left(\frac{t}{2} 
 ---
 
 This example is implemented in:
-- [MATLAB/OCTAVE](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/RK4.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/RK4.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/RK4.cpp)
 
 ## Properties of RK4

--- a/doc/sphinx/source/examples/Time-Integrators/backward_euler.md
+++ b/doc/sphinx/source/examples/Time-Integrators/backward_euler.md
@@ -41,5 +41,5 @@ In the C++ example, we used the fixed-point iteration method for rootfinding due
 ---
 
 This example is implemented in:
-- [MATLAB/Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/backward_euler.m)
+- [Octave](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/backward_euler.m)
 - [C++](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/backward_euler.cpp)

--- a/doc/sphinx/source/examples/index.md
+++ b/doc/sphinx/source/examples/index.md
@@ -1,8 +1,8 @@
 # Examples
 
-The MOLE library contains many examples written in OCTAVE/MATLAB and C++. These examples span a broad range of partial differential equations (PDEs). Below are more technical explanations of the examples included in the library.
+The MOLE library contains many examples written in Octave and C++. These examples span a broad range of partial differential equations (PDEs). Below are more technical explanations of the examples included in the library.
 
-**NOTE**: The name for both OCTAVE/MATLAB and C++ will be the same. The files `elliptic1D.m` and `elliptic1D.cpp` solve the same differential equation explained here under Elliptic1D. There are many more OCTAVE/MATLAB examples, so if you cannot find a C++ example, it is only in the OCTAVE/MATLAB folder.
+**NOTE**: The name for both Octave and C++ will be the same. The files `elliptic1D.m` and `elliptic1D.cpp` solve the same differential equation explained here under Elliptic1D. There are many more Octave examples, so if you cannot find a C++ example, it is only in the Octave folder.
 
 ```{toctree}
 :maxdepth: 1

--- a/doc/sphinx/source/examples/index.md
+++ b/doc/sphinx/source/examples/index.md
@@ -2,7 +2,7 @@
 
 The MOLE library contains many examples written in Octave and C++. These examples span a broad range of partial differential equations (PDEs). Below are more technical explanations of the examples included in the library.
 
-**NOTE**: The name for both Octave and C++ will be the same. The files `elliptic1D.m` and `elliptic1D.cpp` solve the same differential equation explained here under Elliptic1D. There are many more Octave examples, so if you cannot find a C++ example, it is only in the Octave folder.
+**NOTE**: The name for both Octave and C++ will be the same. The files `elliptic1D.m` and `elliptic1D.cpp` solve the same differential equation explained here under Elliptic1D. There are many more Octave examples, so if you cannot find a C++ example, it is only in `examples/matlab_octave/`.
 
 ```{toctree}
 :maxdepth: 1

--- a/doc/sphinx/source/intros/gettingstarted.md
+++ b/doc/sphinx/source/intros/gettingstarted.md
@@ -69,7 +69,7 @@ int main() {
 ```
 ::::
 
-::::{tab-item} MATLAB/Octave
+::::{tab-item} Octave
 ```matlab
 % elliptic1D.m - 1D Poisson's equation with Robin boundary conditions
 
@@ -110,12 +110,12 @@ plot(grid, exp(grid))
 
 For full examples, see:
 - C++: [transport1D.cpp](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp/transport1D.cpp)
-- MATLAB: [elliptic1D.m](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1D.m)
+- Octave: [elliptic1D.m](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave/elliptic1D.m)
 
 ## Next Steps
 
 - Check out more C++ examples in the [examples/cpp/](https://github.com/csrc-sdsu/mole/blob/main/examples/cpp) directory
-- Explore the MATLAB/Octave examples in the [examples/matlab_octave/](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave) directory
+- Explore the Octave examples in the [examples/matlab_octave/](https://github.com/csrc-sdsu/mole/blob/main/examples/matlab_octave) directory
 - Join our community and [contribute](https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md)
 
 ```{include} ../../../../README.md

--- a/doc/sphinx/source/math_functions/CSRCReportOnMOLE.md
+++ b/doc/sphinx/source/math_functions/CSRCReportOnMOLE.md
@@ -121,7 +121,7 @@ are perpendicular to the horizontal, vertical and in depth directions,
 respectively.
 
 There are several ways to generate uniform structured staggered grids
-(in MATLAB/Octave). What is important is to remember that we need to
+(in Octave). What is important is to remember that we need to
 store the coordinates for two different quantities.
 
 Suppose
@@ -162,7 +162,7 @@ $$
 ## Using the Operators
 
 Inside the \"**examples/matlab**\" folder you will find several
-MATLAB/Octave scripts that use MOLE to solve well known partial
+Octave scripts that use MOLE to solve well known partial
 differential equations.
 
 Our selection includes steady-state and time-dependent problems:

--- a/doc/sphinx/source/overview.md
+++ b/doc/sphinx/source/overview.md
@@ -27,6 +27,6 @@ Includes Gradient, Divergence, and Laplacian operators with various boundary con
 
 ```{grid-item-card} <i class="fas fa-laptop-code"></i> Dual Implementation
 :class-card: feature-card
-Available in both C++ and MATLAB/ Octave with consistent interfaces
+Available in both C++ and Octave with consistent interfaces
 ```
 ````


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Example
- [X] Documentation

## Description
Rename the "MATLAB/OCTAVE" references in most of the docs, change to "Octave". 

The folders still have MATLAB, as well as some of the older reports have MATLAB listed. But, it should be clear now that the target is Octave, and we test for both Octave and MATLAB.

## Related Issues & Documents

- Closes #444

## Read Contributing Guide and Code of Conduct

- [X] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [X] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://miro.medium.com/v2/1*VpQb2kbPdj6vXH2pJqi7Qg.gif" width="100" height="100" />
