### PR TITLE
Fixing error with cpp documentation

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -133,11 +133,11 @@ breathe_domain_by_extension = {
     ".c": "c",
 }
 breathe_default_members = ('members', 'undoc-members')
-
 # Run Doxygen if needed during build
 if not os.path.exists(str(ROOT_DIR / "doc/doxygen/cpp/xml/index.xml")):
     print("Doxygen XML not found. Running Doxygen...")
-    subprocess.call(["doxygen", "Doxyfile"], cwd=str(ROOT_DIR))
+    os.makedirs(str(ROOT_DIR / "doc/doxygen/cpp"), exist_ok=True)
+    subprocess.run(["doxygen", "Doxyfile"], cwd=str(ROOT_DIR), check=True)
 
 #------------------------------------------------------------------------------
 # GraphViz configuration


### PR DESCRIPTION
<!--
     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
     - 📖 Read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
     - 📝 Add license information in the appropriate place. See GNU Octave or C++ code for reference.
      
          SPDX-License-Identifier: GPL-3.0-or-later
          © 2008-2024 San Diego State University Research Foundation (SDSURF).
          See LICENSE file or https://www.gnu.org/licenses/gpl-3.0.html for details. 

     NOTE: Pull Requests from forked repositories need to be reviewed by
     a MOLE Team member before any CI builds will run.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Example
- [ ] Documentation

## Description
Fixes documentation error previously reported in issue #458 
if Doxygen fails for any reason (missing dependency, malformed Doxyfile, etc.), the build silently continues and we get the confusing cascade of doxygenclass: _**Cannot find file warnings instead of a clear error pointing at Doxygen.**_
**The solution** is: 
```
# Run Doxygen if needed during build
if not os.path.exists(str(ROOT_DIR / "doc/doxygen/cpp/xml/index.xml")):
    print("Doxygen XML not found. Running Doxygen...")
    os.makedirs(str(ROOT_DIR / "doc/doxygen/cpp"), exist_ok=True)
    subprocess.run(["doxygen", "Doxyfile"], cwd=str(ROOT_DIR), check=True)
```

## Related Issues & Documents
<!--
For Pull Requests that relate or close an Issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.-->

- [X] I have created an Issue that is paired with this PR
- Closes #458 

## QA Instructions, Screenshots, Recordings

The Doxygen documents are automatically built during the MOLE build process.

## Keep-open request
- [ ] I am requesting maintainer review for `keep-open`.

Reason:

## Added/updated tests?
_We encourage you to test all code included with MOLE, including examples.

- [ ] Yes
- [X] No, and this is why: _does not test functionality, the bug is related to the C++ documentation only_
- [ ] I need help with writing tests

## Read Contributing Guide and Code of Conduct

- [X] 📖 I have read the MOLE Contributing Guide: https://github.com/csrc-sdsu/mole/blob/main/CONTRIBUTING.md
- [X] 📖 I have read the MOLE Code of Conduct: https://github.com/csrc-sdsu/mole/blob/main/CODE_OF_CONDUCT.md

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://miro.medium.com/v2/1*VpQb2kbPdj6vXH2pJqi7Qg.gif" width="100" height="100" />
